### PR TITLE
Fix/add point on plane

### DIFF
--- a/plugin.cfg
+++ b/plugin.cfg
@@ -3,5 +3,5 @@
 name="Scatter"
 description="Scatter other scenes in a manually defined area"
 author="HungryProton"
-version="2.7.3"
+version="2.7.4"
 script="plugin.gd"

--- a/plugin.gd
+++ b/plugin.gd
@@ -4,6 +4,7 @@ extends EditorPlugin
 
 const Util = preload("src/util.gd")
 const ScatterPath = preload("./src/core/scatter_path.gd")
+const Scatter = preload("./src/core/scatter.gd")
 
 var _modifier_stack_plugin: EditorInspectorPlugin = preload("./src/tools/modifier_stack_inspector_plugin/modifier_stack_plugin.gd").new()
 var _scatter_path_gizmo_plugin: EditorSpatialGizmoPlugin = preload("./src/tools/path_gizmo/scatter_path_gizmo_plugin.gd").new()
@@ -91,7 +92,9 @@ func _on_selection_changed() -> void:
 	else:
 		_show_options_panel()
 		_scatter_path_gizmo_plugin.set_selected(selected[0])
-		selected[0].undo_redo = get_undo_redo()
+
+		if selected[0] is Scatter:
+			selected[0].undo_redo = get_undo_redo()
 
 		if _gizmo_options.snap_to_colliders():
 			_on_snap_to_colliders_enabled()

--- a/plugin.gd
+++ b/plugin.gd
@@ -50,6 +50,7 @@ func _enter_tree():
 		preload("./icons/group.svg")
 	)
 
+	set_input_event_forwarding_always_enabled()
 	_setup_options_panel()
 
 	_scatter_path_gizmo_plugin.editor_plugin = self
@@ -62,7 +63,6 @@ func _enter_tree():
 	connect("scene_changed", self, "_on_scene_changed")
 
 
-
 func _exit_tree():
 	remove_inspector_plugin(_modifier_stack_plugin)
 	remove_custom_type("Scatter")
@@ -73,6 +73,13 @@ func _exit_tree():
 	remove_spatial_gizmo_plugin(_scatter_path_gizmo_plugin)
 	remove_spatial_gizmo_plugin(_point_gizmo_plugin)
 	_gizmo_options.queue_free()
+
+
+func forward_spatial_gui_input(camera: Camera, _event: InputEvent) -> bool:
+	if _scatter_path_gizmo_plugin:
+		_scatter_path_gizmo_plugin.set_editor_camera(camera)
+
+	return false
 
 
 func _on_selection_changed() -> void:

--- a/src/tools/path_gizmo/gizmo_options.gd
+++ b/src/tools/path_gizmo/gizmo_options.gd
@@ -13,6 +13,7 @@ onready var _options_button: Button = $VBoxContainer/Options
 onready var _options: Control = $VBoxContainer/MarginContainer
 onready var _grid_density: SpinBox = $VBoxContainer/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/GridDensity/SpinBox
 onready var _hide_grid: CheckButton = $VBoxContainer/MarginContainer/VBoxContainer/HideGrid
+onready var _force_plane_projection: CheckButton = $VBoxContainer/MarginContainer/VBoxContainer/ForceProjection
 onready var _path_color: ColorRect = $VBoxContainer/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/PathColor/MarginContainer/Button/ColorRect
 onready var _grid_color: ColorRect = $VBoxContainer/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/GridColor/MarginContainer/Button/ColorRect
 onready var _color_picker: ColorPicker = $Popup/MarginContainer/ColorPicker
@@ -41,6 +42,10 @@ func lock_to_plane() -> bool:
 
 func hide_grid() -> bool:
 	return _hide_grid.pressed
+
+
+func force_plane_projection() -> bool:
+	return _force_plane_projection.pressed
 
 
 func get_path_color() -> Color:
@@ -76,13 +81,14 @@ func _load_config_file() -> bool:
 	if err != OK:
 		return false
 
-	_path_color.color = config.get_value("colors", "path")
-	_grid_color.color = config.get_value("colors", "grid")
+	_path_color.color = config.get_value("colors", "path", Color("ff2f2f"))
+	_grid_color.color = config.get_value("colors", "grid", Color("c8ffbe11"))
 
-	_colliders.pressed = config.get_value("general", "snap_to_colliders")
-	_plane.pressed = config.get_value("general", "lock_to_plane")
-	_hide_grid.pressed = config.get_value("general", "always_hide_grid")
-	_grid_density.value = config.get_value("general", "grid_density")
+	_colliders.pressed = config.get_value("general", "snap_to_colliders", false)
+	_plane.pressed = config.get_value("general", "lock_to_plane", true)
+	_hide_grid.pressed = config.get_value("general", "always_hide_grid", false)
+	_grid_density.value = config.get_value("general", "grid_density", 7)
+	_force_plane_projection.pressed = config.get_value("general", "force_plane_projection", false)
 
 	return true
 
@@ -96,6 +102,7 @@ func _save_config_file() -> void:
 	config.set_value("general", "lock_to_plane", _plane.pressed)
 	config.set_value("general", "always_hide_grid", _hide_grid.pressed)
 	config.set_value("general", "grid_density", _grid_density.value)
+	config.set_value("general", "force_plane_projection", _force_plane_projection.pressed)
 
 	config.save("user://scatter_config.cfg")
 

--- a/src/tools/path_gizmo/gizmo_options.tscn
+++ b/src/tools/path_gizmo/gizmo_options.tscn
@@ -70,11 +70,11 @@ align = 0
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer"]
 margin_top = 112.0
 margin_right = 316.0
-margin_bottom = 228.0
+margin_bottom = 272.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/MarginContainer"]
 margin_right = 316.0
-margin_bottom = 116.0
+margin_bottom = 160.0
 
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/MarginContainer/VBoxContainer"]
 margin_right = 316.0
@@ -99,8 +99,8 @@ size_flags_horizontal = 3
 text = "Path color"
 
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/PathColor"]
-margin_left = 281.0
-margin_right = 305.0
+margin_left = 282.0
+margin_right = 306.0
 margin_bottom = 20.0
 size_flags_horizontal = 4
 size_flags_vertical = 4
@@ -110,8 +110,7 @@ custom_constants/margin_left = 0
 custom_constants/margin_bottom = 0
 
 [node name="Button" type="Button" parent="VBoxContainer/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/PathColor/MarginContainer"]
-margin_left = -1.0
-margin_right = 23.0
+margin_right = 24.0
 margin_bottom = 20.0
 rect_min_size = Vector2( 24, 20 )
 size_flags_horizontal = 4
@@ -130,7 +129,7 @@ __meta__ = {
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
-color = Color( 1, 0.183594, 0.183594, 1 )
+color = Color( 1, 0.184314, 0.184314, 1 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -154,8 +153,8 @@ size_flags_horizontal = 3
 text = "Grid color"
 
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/GridColor"]
-margin_left = 281.0
-margin_right = 305.0
+margin_left = 282.0
+margin_right = 306.0
 margin_bottom = 20.0
 size_flags_horizontal = 4
 size_flags_vertical = 4
@@ -165,8 +164,7 @@ custom_constants/margin_left = 0
 custom_constants/margin_bottom = 0
 
 [node name="Button" type="Button" parent="VBoxContainer/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/GridColor/MarginContainer"]
-margin_left = -1.0
-margin_right = 23.0
+margin_right = 24.0
 margin_bottom = 20.0
 rect_min_size = Vector2( 24, 0 )
 size_flags_horizontal = 4
@@ -188,7 +186,7 @@ __meta__ = {
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
-color = Color( 1, 0.74472, 0.0664062, 0.784314 )
+color = Color( 1, 0.745098, 0.0666667, 0.784314 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -227,8 +225,13 @@ margin_bottom = 116.0
 focus_mode = 0
 text = "Always hide the grid"
 
+[node name="ForceProjection" type="CheckButton" parent="VBoxContainer/MarginContainer/VBoxContainer"]
+margin_top = 120.0
+margin_right = 316.0
+margin_bottom = 160.0
+text = "Force plane projection"
+
 [node name="Popup" type="PopupPanel" parent="."]
-visible = true
 margin_left = 4.0
 margin_top = 4.0
 margin_right = 320.0
@@ -259,4 +262,5 @@ __meta__ = {
 [connection signal="pressed" from="VBoxContainer/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/GridColor/MarginContainer/Button" to="." method="_on_grid_color_select"]
 [connection signal="value_changed" from="VBoxContainer/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/GridDensity/SpinBox" to="." method="_on_button_toggled"]
 [connection signal="toggled" from="VBoxContainer/MarginContainer/VBoxContainer/HideGrid" to="." method="_on_button_toggled"]
+[connection signal="toggled" from="VBoxContainer/MarginContainer/VBoxContainer/ForceProjection" to="." method="_on_button_toggled"]
 [connection signal="color_changed" from="Popup/MarginContainer/ColorPicker" to="." method="_on_color_changed"]


### PR DESCRIPTION
This fix projects the newly added points to the plane if the `Lock to plane` option is enabled.

However, there doesn't seem to be a way in Godot to tell the difference between a regular action and a redo command. As a result, redo won't work as expected with newly created points. (It still works fine with the other actions, though. This will likely be fixed in the Godot 4 version of this addon).

This feature is disabled by default. You can enable it in the options' panel on the left.

![image](https://user-images.githubusercontent.com/52043844/133595834-b75342f6-562b-4136-994c-75314318e1b1.png)
