### PR TITLE
Multimesh splitting

### DIFF
--- a/src/core/scatter.gd
+++ b/src/core/scatter.gd
@@ -6,10 +6,10 @@ var Scatter = preload("namespace.gd").new()
 
 export var global_seed := 0 setget _set_global_seed
 export var use_instancing := true setget _set_instancing
-export var split_multimesh := false setget _split_multimesh
-export var split_x_count : = 1
-export var split_y_count : = 1
-export var split_z_count : = 1
+var split_multimesh := false setget _split_multimesh
+var split_count_x : = 1
+var split_count_y : = 1
+var split_count_z : = 1
 export var disable_updates_in_game := true
 export var disable_automatic_updates = false
 export var force_update_when_loaded := true
@@ -59,9 +59,32 @@ func _get_configuration_warning() -> String:
 
 func _get_property_list() -> Array:
 	var list := []
-
+	
+	list.append({
+		name = "Split Multimesh",
+		type = TYPE_NIL,
+		hint_string = "split",
+		usage = PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SCRIPT_VARIABLE
+	})
+	list.append({
+		name = "split_multimesh",
+		type = TYPE_BOOL
+	})
+	list.append({
+		name = "split_count_x",
+		type = TYPE_INT
+	})
+	list.append({
+		name = "split_count_y",
+		type = TYPE_INT
+	})
+	list.append({
+		name = "split_count_z",
+		type = TYPE_INT
+	})
+	
 	# Used to display the modifier stack in an inspector plugin.
-	list.push_back({
+	list.append({
 		name = "modifier_stack",
 		type = TYPE_OBJECT,
 		hint_string =  "ScatterModifierStack",
@@ -305,20 +328,20 @@ func _create_split_sibling(mmi : MultiMeshInstance, parent : Spatial) -> bool:
 	if mmi.multimesh.instance_count <= 0:
 		print("Cannot create split sibling, multimesh is empty")
 		return false
-	if split_x_count <= 0 or split_y_count <= 0 or split_z_count <= 0:
+	if split_count_x <= 0 or split_count_y <= 0 or split_count_z <= 0:
 		print("Cannot create split sibling, invaild split counts")
 		return false
 	
 	var mmi_siblings = []
 	var transforms = []
 	# Create mmis and multimeshes for all siblings
-	for xi in range(split_x_count):
+	for xi in range(split_count_x):
 		mmi_siblings.append([])
 		transforms.append([])
-		for yi in range(split_y_count):
+		for yi in range(split_count_y):
 			mmi_siblings[xi].append([])
 			transforms[xi].append([])
-			for zi in range(split_z_count):
+			for zi in range(split_count_z):
 				transforms[xi][yi].append([])
 				var sibling = MultiMeshInstance.new()
 				mmi_siblings[xi][yi].append(sibling)
@@ -343,14 +366,14 @@ func _create_split_sibling(mmi : MultiMeshInstance, parent : Spatial) -> bool:
 		var t = mmi.multimesh.get_instance_transform(i)
 		var p_rel = (t.origin - aabb.position) / aabb.size
 		# Chunk index
-		var ci = (p_rel * Vector3(split_x_count, split_y_count, split_z_count)).floor()
+		var ci = (p_rel * Vector3(split_count_x, split_count_y, split_count_z)).floor()
 		# Store the transform to the appropriate array
 		transforms[ci.x][ci.y][ci.z].append(t)
 	
 	# apply transforms, add to tree all non-empty multimesh instances
-	for zi in range(split_z_count):
-		for yi in range(split_y_count):
-			for xi in range(split_x_count):
+	for zi in range(split_count_z):
+		for yi in range(split_count_y):
+			for xi in range(split_count_x):
 				# reference to current mmi based on chunk index
 				var c_mmi : MultiMeshInstance = mmi_siblings[xi][yi][zi]
 				if transforms[xi][yi][zi].size() == 0:

--- a/src/core/scatter.gd
+++ b/src/core/scatter.gd
@@ -316,6 +316,9 @@ func _create_split_sibling(mmi : MultiMeshInstance, parent : Spatial) -> void:
 						chunkTransforms.append(t)
 						print("Has: ", i)
 				
+				if chunkTransforms.size() == 0:
+					continue
+				
 				sibling.multimesh.instance_count = chunkTransforms.size()
 				for i in range(chunkTransforms.size()):
 					sibling.multimesh.set_instance_transform(i, chunkTransforms[i])
@@ -323,6 +326,7 @@ func _create_split_sibling(mmi : MultiMeshInstance, parent : Spatial) -> void:
 				
 				sibling.add_to_group("split_multimesh")
 				parent.add_child(sibling)
+				sibling.global_transform = mmi.global_transform
 				sibling.owner = get_tree().edited_scene_root
 				
 

--- a/src/core/scatter.gd
+++ b/src/core/scatter.gd
@@ -11,6 +11,7 @@ export var split_x_count : = 1
 export var split_y_count : = 1
 export var split_z_count : = 1
 export var disable_updates_in_game := true
+export var disable_automatic_updates = false
 export var force_update_when_loaded := true
 export var make_children_unselectable := true
 export var preview_count := -1
@@ -99,6 +100,8 @@ func clear() -> void:
 func update() -> void:
 	if disable_updates_in_game and not Engine.is_editor_hint():
 		return
+	if disable_automatic_updates:
+		return
 	_do_update()
 
 
@@ -147,7 +150,7 @@ func full_update() -> void:
 	_delete_duplicates()
 	_delete_multimeshes()
 	yield(get_tree(), "idle_frame")
-	update()
+	_do_update()
 
 
 # Loop through children to find all the ScatterItem nodes

--- a/src/core/scatter.gd
+++ b/src/core/scatter.gd
@@ -311,12 +311,6 @@ func _create_split_sibling(mmi : MultiMeshInstance, parent : Spatial) -> bool:
 				sibling.multimesh.mesh = mmi.multimesh.mesh
 				sibling.multimesh.transform_format = 1
 				sibling.material_override = mmi.material_override
-				
-				sibling.add_to_group("split_multimesh")
-				parent.add_child(sibling)
-				sibling.global_transform = mmi.global_transform
-				sibling.owner = get_tree().edited_scene_root
-				property_list_changed_notify()
 	
 	# Create the AABB from all instances
 	var aabb = mmi.get_aabb()
@@ -324,7 +318,7 @@ func _create_split_sibling(mmi : MultiMeshInstance, parent : Spatial) -> bool:
 	aabb = aabb.grow(0.1)
 	
 	# Collect the transforms to transform arrays
-	# This step is necessary because mmi transforms reset when instance count changes
+	# This step is necessary to separate because mmi transforms reset when instance count changes
 	for i in mmi.multimesh.instance_count:
 		# both aabb and t are in mmi's local coordinates
 		var t = mmi.multimesh.get_instance_transform(i)
@@ -334,7 +328,7 @@ func _create_split_sibling(mmi : MultiMeshInstance, parent : Spatial) -> bool:
 		# Store the transform to the appropriate array
 		transforms[ci.x][ci.y][ci.z].append(t)
 	
-	# apply transforms and remove empty multimesh instances
+	# apply transforms, add to tree all non-empty multimesh instances
 	for zi in range(split_z_count):
 		for yi in range(split_y_count):
 			for xi in range(split_x_count):
@@ -346,7 +340,12 @@ func _create_split_sibling(mmi : MultiMeshInstance, parent : Spatial) -> bool:
 					c_mmi.multimesh.instance_count = transforms[xi][yi][zi].size()
 					for i in range(transforms[xi][yi][zi].size()):
 						c_mmi.multimesh.set_instance_transform(i, transforms[xi][yi][zi][i])
-						
+					parent.add_child(c_mmi)
+					c_mmi.global_transform = mmi.global_transform
+					c_mmi.owner = get_tree().edited_scene_root
+					c_mmi.add_to_group("split_multimesh")
+					#TODO make group appear in editor
+	
 	return true
 
 # Create a multimesh for item if it does not exist yet


### PR DESCRIPTION
# Multimesh splitting is implemented for the plugin.

This feature is useful for large multimeshes that are created with the plugin, allowing culling to take place in batches.
The feature was tested on the showcase scene included in the plugin.

## Usage
A new checkbox is shown in the inspector of scatter nodes. 
The number of chunks can be specified for each axis with the Split N count parameter.
When the split multimesh checkbox is checked the chunks are created and saved under the scatter node and the original multimesh instance created by the plugin is hidden, but not deleted.
When the split multimesh checkbox is unchecked the split multimesh instances are deleted and the original multimesh instances are set visible.