### PR TITLE
Poisson path

### DIFF
--- a/src/modifiers/distribute_along_poisson.gd
+++ b/src/modifiers/distribute_along_poisson.gd
@@ -1,0 +1,50 @@
+tool
+extends "base_modifier.gd"
+
+export var override_global_seed := false
+export var custom_seed := 0
+export var distribution_radius := 1.0
+export var distribution_retries := 20
+export var width := 1
+
+var _sampler = preload("../common/poisson_disc_sampling.gd").new()
+
+
+func _init() -> void:
+	display_name = "Distribute Along (Poisson)"
+	category = "Distribute"
+	warning_ignore_no_transforms = true
+	warning_ignore_no_path = false
+
+
+func _process_transforms(transforms, global_seed) -> void:
+	_sampler.rng = RandomNumberGenerator.new()
+
+	if override_global_seed:
+		_sampler.rng.set_seed(custom_seed)
+	else:
+		_sampler.rng.set_seed(global_seed)
+
+	var rect_pos = Vector2(transforms.path.bounds_min.x - width, transforms.path.bounds_min.z - width)
+	var rect_size = Vector2(transforms.path.size.x + (width * 2), transforms.path.size.z + (width * 2)) 
+	var bounds = Rect2(rect_pos, rect_size)
+	var retries = distribution_retries
+	if transforms.max_count >= 0:
+		retries = 1
+
+	var samples = _sampler.generate_points(distribution_radius, bounds, retries)
+	transforms.resize(samples.size())
+
+	if transforms.list.size() == 0:
+		transforms.add(samples.size())
+
+	var matched_samples: int = 0
+	for s in samples:
+		if matched_samples == transforms.list.size():
+			break
+		var s3 = Vector3(s.x, 0, s.y)
+		if (transforms.path.curve.get_closest_point(s3) - s3).length() < width:
+			transforms.list[matched_samples].origin = Vector3(s.x, transforms.list[matched_samples].origin.y, s.y)
+			matched_samples += 1
+
+	transforms.list.resize(matched_samples)


### PR DESCRIPTION
I implemented a new distribution based on the existing poisson distribution that distributes objects along a path with a specific width. 

![image](https://user-images.githubusercontent.com/36245389/184909588-bd0beff6-dfeb-4ab5-80f2-3c438ea414ae.png)


Our use case for this distribution is to create a cobblestone path. When done with the existing distributions it was hard to get a result that both aligned nicely with the path and didn't create overlapping stones on the inner portions of tight turns. Sparse placement was also a problem on the longer arc on the outside of the turn.

![image](https://user-images.githubusercontent.com/36245389/184910152-0f13e5d8-5a53-4157-8081-a3676b5bbc6c.png)

I think the results look nice and it could be useful for others as well.