### PR TITLE
Visibility range for split multimesh

### DIFF
--- a/src/core/scatter.gd
+++ b/src/core/scatter.gd
@@ -1,6 +1,7 @@
 tool
 extends "scatter_path.gd"
 
+const SplitMultimeshContainer = preload("./split_multimesh_container.gd")
 
 var Scatter = preload("namespace.gd").new()
 

--- a/src/core/scatter.gd
+++ b/src/core/scatter.gd
@@ -301,11 +301,18 @@ func _add_split_multimesh():
 	for child in _items:
 		var mmi = child.get_node("MultiMeshInstance")
 		# Create a parent container
-		var container = Spatial.new()
+		var container = SplitMultimeshContainer.new()
 		child.add_child(container)
 		container.global_transform = self.global_transform
 		container.owner = get_tree().edited_scene_root
 		container.name = "SplitMultimesh"
+
+		# Copy visible range settings to containers
+		if "visible_range_begin" in child: #sanity check
+			container.visible_range_begin = child.visible_range_begin
+			container.visible_range_begin_hysteresis = child.visible_range_begin_hysteresis
+			container.visible_range_end = child.visible_range_end
+			container.visible_range_end_hysteresis = child.visible_range_end_hysteresis
 
 		if _create_split_sibling(mmi, container):
 			mmi.visible = false

--- a/src/core/scatter.gd
+++ b/src/core/scatter.gd
@@ -18,6 +18,11 @@ var split_count_x : = 1
 var split_count_y : = 1
 var split_count_z : = 1
 
+var split_visible_range_begin : float = 0
+var split_visible_range_begin_hysteresis : float = 0.1
+var split_visible_range_end : float   = 0
+var split_visible_range_end_hysteresis : float = 0.1
+
 var undo_redo setget _set_undo_redo
 var is_moving := false setget _set_is_moving
 
@@ -83,6 +88,23 @@ func _get_property_list() -> Array:
 	list.append({
 		name = "split_count_z",
 		type = TYPE_INT
+	})
+	
+	list.append({
+		name = "split_visible_range_begin",
+		type = TYPE_REAL
+	})
+	list.append({
+		name = "split_visible_range_begin_hysteresis",
+		type = TYPE_REAL
+	})
+	list.append({
+		name = "split_visible_range_end",
+		type = TYPE_REAL
+	})
+	list.append({
+		name = "split_visible_range_end_hysteresis",
+		type = TYPE_REAL
 	})
 
 	# Used to display the modifier stack in an inspector plugin.
@@ -308,11 +330,10 @@ func _add_split_multimesh():
 		container.name = "SplitMultimesh"
 
 		# Copy visible range settings to containers
-		if "visible_range_begin" in child: #sanity check
-			container.visible_range_begin = child.visible_range_begin
-			container.visible_range_begin_hysteresis = child.visible_range_begin_hysteresis
-			container.visible_range_end = child.visible_range_end
-			container.visible_range_end_hysteresis = child.visible_range_end_hysteresis
+		container.visible_range_begin = split_visible_range_begin
+		container.visible_range_begin_hysteresis = split_visible_range_begin_hysteresis
+		container.visible_range_end = split_visible_range_end
+		container.visible_range_end_hysteresis = split_visible_range_end_hysteresis
 
 		if _create_split_sibling(mmi, container):
 			mmi.visible = false

--- a/src/core/scatter_item.gd
+++ b/src/core/scatter_item.gd
@@ -12,6 +12,11 @@ export var ignore_initial_position := true setget _set_ignore_pos
 export var ignore_initial_rotation := true setget _set_ignore_rot
 export var ignore_initial_scale := true setget _set_ignore_scale
 
+export var visible_range_begin : float = 0
+export var visible_range_begin_hysteresis : float = 0.1
+export var visible_range_end : float   = 0
+export var visible_range_end_hysteresis : float = 0.1
+
 var use_instancing := true setget _set_use_instancing
 var merge_target_meshes := false setget _set_merge_target_meshes
 var cast_shadow := 1 setget _set_cast_shadow

--- a/src/core/scatter_item.gd
+++ b/src/core/scatter_item.gd
@@ -12,11 +12,6 @@ export var ignore_initial_position := true setget _set_ignore_pos
 export var ignore_initial_rotation := true setget _set_ignore_rot
 export var ignore_initial_scale := true setget _set_ignore_scale
 
-export var visible_range_begin : float = 0
-export var visible_range_begin_hysteresis : float = 0.1
-export var visible_range_end : float   = 0
-export var visible_range_end_hysteresis : float = 0.1
-
 var use_instancing := true setget _set_use_instancing
 var merge_target_meshes := false setget _set_merge_target_meshes
 var cast_shadow := 1 setget _set_cast_shadow

--- a/src/core/split_multimesh_container.gd
+++ b/src/core/split_multimesh_container.gd
@@ -24,21 +24,19 @@ func _process(delta):
 			var show = true
 			
 			if visible_range_begin != 0:
-				if d >= visible_range_begin + visible_range_begin_hysteresis:
-					pass
-				else:
-					show = false
-				
 				if d <= visible_range_begin - visible_range_begin_hysteresis:
+					# Too close, hide
 					hide = true
+				# if inside hysteresis band do not change visibility
+				if abs(d-visible_range_begin) < visible_range_begin_hysteresis:
+					show = false
 			
 			if visible_range_end != 0:
 				if d >= visible_range_end + visible_range_end_hysteresis:
+					# Too far, hide
 					hide = true
-				
-				if d <= visible_range_end - visible_range_end_hysteresis:
-					pass
-				else:
+				# if inside hysteresis band do not change visiblity
+				if abs(d-visible_range_end) < visible_range_end_hysteresis:
 					show = false
 			
 			if hide:

--- a/src/core/split_multimesh_container.gd
+++ b/src/core/split_multimesh_container.gd
@@ -1,4 +1,3 @@
-class_name SplitMultimeshContainer
 extends Spatial
 
 var visible_range_begin : float = 0
@@ -10,6 +9,8 @@ func _ready():
 	pass
 
 func _process(delta):
+	if visible_range_end == 0 and visible_range_end == 0:
+		return
 	var cam = get_viewport().get_camera()
 	if cam != null:
 		for child in get_children():
@@ -43,5 +44,3 @@ func _process(delta):
 				child.visible = false
 			elif show:
 				child.visible = true
-		pass
-	pass

--- a/src/core/split_multimesh_container.gd
+++ b/src/core/split_multimesh_container.gd
@@ -1,0 +1,49 @@
+class_name SplitMultimeshContainer
+extends Spatial
+
+var visible_range_begin : float = 0
+var visible_range_begin_hysteresis : float = 0.1
+var visible_range_end : float   = 0
+var visible_range_end_hysteresis : float = 0.1
+
+func _ready():
+	pass
+
+func _process(delta):
+	var cam = get_viewport().get_camera()
+	if cam != null:
+		for child in get_children():
+			if not child is MultiMeshInstance:
+				continue
+			var aabb : AABB = child.get_aabb()
+			var center = aabb.position + aabb.size / 2.0
+			center = child.global_transform * center
+			var d = (cam.global_transform.origin - center).length()
+			
+			var hide = false
+			var show = true
+			
+			if visible_range_begin != 0:
+				if d >= visible_range_begin + visible_range_begin_hysteresis:
+					pass
+				else:
+					show = false
+				
+				if d <= visible_range_begin - visible_range_begin_hysteresis:
+					hide = true
+			
+			if visible_range_end != 0:
+				if d >= visible_range_end + visible_range_end_hysteresis:
+					hide = true
+				
+				if d <= visible_range_end - visible_range_end_hysteresis:
+					pass
+				else:
+					show = false
+			
+			if hide:
+				child.visible = false
+			elif show:
+				child.visible = true
+		pass
+	pass


### PR DESCRIPTION
I implemented a visibility range for the generated split multimeshes. 
This feature is useful again for large terrains full of grass because the far away chunks can be hidden.
It is also possible to use it as a very barebones manual LOD system by adding multiple scatter items with complementing visible ranges.
It is also possible to set hysteresis to avoid meshes frequently popping in and out of existence.

![image](https://user-images.githubusercontent.com/36245389/184936799-13eb01e3-9323-4dfc-865e-cf265f94a3a7.png)
