### PR TITLE
Add option to not store instance data

### DIFF
--- a/src/core/scatter.gd
+++ b/src/core/scatter.gd
@@ -212,6 +212,7 @@ func full_update() -> void:
 	_reset_all_colliders(get_tree().root)
 	_delete_duplicates()
 	_delete_multimeshes()
+	_remove_split_multimesh()
 	yield(get_tree(), "idle_frame")
 	_do_update()
 
@@ -362,13 +363,11 @@ func _remove_split_multimesh():
 		_discover_items()
 
 	# Remove split siblings
-	for child in _items:
-		var siblingContainer = child.find_node("SplitMultimesh*")
-		while siblingContainer != null:
-			# Remove split siblings
-			child.remove_child(siblingContainer) # next loop must not find this
-			siblingContainer.queue_free()
-			siblingContainer = child.find_node("SplitMultimesh*")
+	for item in _items:
+		for child in item.get_children():
+			if "is_split_multimesh_container" in child:
+				item.remove_child(child)
+				child.queue_free()
 
 	# Make original multimeshes visible again
 	for child in _items:

--- a/src/core/split_multimesh_container.gd
+++ b/src/core/split_multimesh_container.gd
@@ -5,6 +5,8 @@ var visible_range_begin_hysteresis : float = 0.1
 var visible_range_end : float   = 0
 var visible_range_end_hysteresis : float = 0.1
 
+var is_split_multimesh_container = true
+
 func _ready():
 	pass
 


### PR DESCRIPTION
This solves issue #90.
I added a checkbox that can disable saving the multimesh to the tscn file. 
It also works with split multimesh.

Obviously this requires to enable the option to update the scene when loaded, otherwise the scatter is never created.

As far as I can tell, all other cases where the owner is set in code is tied to duplicating scatters. Accordingly duplicating still works without issues for both cases (saving instances and not).

I have not found any issues during my tests, but it was a bit limited so more tests might be needed.