### PR TITLE
Bugfixes, remove redundant code

### DIFF
--- a/src/core/scatter.gd
+++ b/src/core/scatter.gd
@@ -324,20 +324,11 @@ func _split_multimesh_set(set):
 	split_enabled = set
 
 
-func _get_multimesh_from_item(item):
-	var mmi = null
-	for child in item.get_children():
-		# find first multimesh, should be only one
-		if child is MultiMeshInstance:
-			mmi = child
-			break
-	return mmi
-
 
 func _add_split_multimesh():
 	# create split siblings from all multimesh
 	for child in _items:
-		var mmi = _get_multimesh_from_item(child)
+		var mmi = child.get_multimesh_instance()
 		if not mmi:
 			return
 		# Create a parent container
@@ -365,14 +356,15 @@ func _remove_split_multimesh():
 
 	# Remove split siblings
 	for item in _items:
-		for child in item.get_children():
-			if "is_split_multimesh_container" in child:
-				item.remove_child(child)
-				child.queue_free()
+		var c_mmi = item.get_split_multimesh_container()
+		while c_mmi != null:
+			item.remove_child(c_mmi)
+			c_mmi.queue_free()
+			c_mmi = item.get_split_multimesh_container()
 
 	# Make original multimeshes visible again
 	for child in _items:
-		var mmi = _get_multimesh_from_item(child)
+		var mmi = child.get_multimesh_instance()
 		if not mmi:
 			continue
 		mmi.visible = true

--- a/src/core/split_multimesh_container.gd
+++ b/src/core/split_multimesh_container.gd
@@ -1,11 +1,13 @@
 extends Spatial
 
-var visible_range_begin : float = 0
-var visible_range_begin_hysteresis : float = 0.1
-var visible_range_end : float   = 0
-var visible_range_end_hysteresis : float = 0.1
+# These variables need to be exported to be able to save them to the scene
+# Do not modify them directly, modify the options in the scatter instance
+export var visible_range_begin : float = 0
+export var visible_range_begin_hysteresis : float = 0.1
+export var visible_range_end : float   = 0
+export var visible_range_end_hysteresis : float = 0.1
 
-var is_split_multimesh_container = true
+export var is_split_multimesh_container = true
 
 func _ready():
 	pass
@@ -18,10 +20,12 @@ func _process(delta):
 		for child in get_children():
 			if not child is MultiMeshInstance:
 				continue
-			var aabb : AABB = child.get_aabb()
-			var center = aabb.position + aabb.size / 2.0
-			center = child.global_transform * center
-			var d = (cam.global_transform.origin - center).length()
+			var mmi_aabb : AABB = child.get_aabb()
+			var center = child.global_transform * mmi_aabb.get_center()
+			var d = cam.global_transform.origin.distance_to(center)
+			# subtract the half size of the aabb to get the distance to the edge of the mmi
+			d -= mmi_aabb.size.length() / 2.0
+			d = max(0, d) # if inside sphere make distance 0
 			
 			var hide = false
 			var show = true


### PR DESCRIPTION
 - Redundant `_get_multimesh_from_item` removed from `scatter.gd`. Now using the functions of class `scatter_item`.
 - `visible_range_*` variables made extern. This is necessary to ensure the options are saved to disk. This is needed in case the scatter is not updated when the scene is loaded.
 -  The `is_split_multimesh_container` variable made extern. The detection of this variables existence is unreliable otherwise. This resulted in strange duplication bugs when opening and closing the scene repeatedly. 
 - Visibility range is now calculated from the edge of the AABB. This makes more sense. This way the parameter can remain the same when the chunk size changes and still the closest mesh becomes visible at the previously set distance. 