### PR TITLE
Fix static typing and physics process access

### DIFF
--- a/src/common/bounds.gd
+++ b/src/common/bounds.gd
@@ -1,5 +1,5 @@
 @tool
-extends Resource
+class_name Bounds extends Resource
 
 # Essentially a Rect3
 # Used by the Domain class

--- a/src/common/event_util.gd
+++ b/src/common/event_util.gd
@@ -1,4 +1,4 @@
-extends RefCounted
+class_name EventUtil extends RefCounted
 
 # Utility class that mimics the Input class behavior
 #

--- a/src/common/scatter_util.gd
+++ b/src/common/scatter_util.gd
@@ -1,11 +1,11 @@
-extends Node
+class_name ScatterUtil extends Node
 
 # To prevent the other core scripts from becoming too large, some of their
 # utility functions are written here (only the functions that don't disturb
 # reading the core code, mostly data validation and other verbose checks).
 
 
-const ModifierStack := preload("../stack/modifier_stack.gd")
+#const ModifierStack := preload("../stack/modifier_stack.gd")
 
 
 ### SCATTER UTILITY FUNCTIONS ###
@@ -36,7 +36,7 @@ static func ensure_output_root_exists(s: Node) -> void:
 	enforce_output_root_owner(s)
 
 
-static func enforce_output_root_owner(s) -> void:
+static func enforce_output_root_owner(s:Scatter) -> void:
 	if is_instance_valid(s.output_root) and s.is_inside_tree():
 		if s.show_output_in_tree:
 			set_owner_recursive(s.output_root, s.get_tree().get_edited_scene_root())

--- a/src/common/transform_list.gd
+++ b/src/common/transform_list.gd
@@ -1,5 +1,5 @@
 @tool
-extends RefCounted
+class_name TransformList extends RefCounted
 
 
 var list: Array[Transform3D] = []

--- a/src/common/util.gd
+++ b/src/common/util.gd
@@ -1,5 +1,5 @@
 @tool
-extends RefCounted
+class_name Util extends RefCounted
 
 
 # Create a new Mesh with as many surfaces as inputs

--- a/src/documentation/documentation.gd
+++ b/src/documentation/documentation.gd
@@ -1,13 +1,13 @@
 @tool
-extends PopupPanel
+class_name Documentation extends PopupPanel
 
 
 # Formats and displays the DocumentationData provided by other parts of the addon
 # TODO: Adjust title font size based on the editor font size / scaling
 
 
-const DocumentationInfo = preload("./documentation_info.gd")
-const SpecialPages = preload("./pages/special_pages.gd")
+#const DocumentationInfo = preload("./documentation_info.gd")
+#const SpecialPages = preload("./pages/special_pages.gd")
 
 var _pages := {}
 var _items := {}

--- a/src/documentation/documentation_info.gd
+++ b/src/documentation/documentation_info.gd
@@ -1,5 +1,5 @@
 @tool
-extends RefCounted
+class_name DocumentationInfo extends RefCounted
 
 
 # Stores raw documentation data.
@@ -10,7 +10,7 @@ extends RefCounted
 
 # Formatting is handled by the main Documentation class.
 
-const Util := preload("../common/util.gd")
+#const Util := preload("../common/util.gd")
 
 
 class Warning:

--- a/src/documentation/pages/special_pages.gd
+++ b/src/documentation/pages/special_pages.gd
@@ -1,7 +1,7 @@
 @tool
-extends RefCounted
+class_name SpecialPages extends RefCounted
 
-const DocumentationInfo = preload("../documentation_info.gd")
+#const DocumentationInfo = preload("../documentation_info.gd")
 
 
 static func get_scatter_documentation() -> DocumentationInfo:

--- a/src/documentation/panel.tscn
+++ b/src/documentation/panel.tscn
@@ -10,13 +10,8 @@ split_offset = 250
 
 [node name="Tree" type="Tree" parent="."]
 layout_mode = 2
-offset_right = 250.0
-offset_bottom = 648.0
 
 [node name="RichTextLabel" type="RichTextLabel" parent="."]
 layout_mode = 2
-offset_left = 262.0
-offset_right = 1152.0
-offset_bottom = 648.0
 bbcode_enabled = true
 text = "[center] [b] [i] Documentation page [/i] [/b] [/center]"

--- a/src/modifiers/project_on_geometry.gd
+++ b/src/modifiers/project_on_geometry.gd
@@ -86,11 +86,13 @@ func _init() -> void:
 		scene when you're editing it.")
 
 
-func _process_transforms(transforms, domain, _seed) -> void:
+func _process_transforms(transforms, domain:Domain, _seed) -> void:
 	if transforms.is_empty():
 		return
-
-	var space_state: PhysicsDirectSpaceState3D = domain.space_state
+#	This modifier depends on physics, as such we need to execute this in the
+#	physics process and retrieve the direct space state using the rid stored in the domain
+	await domain.root.get_tree().physics_frame # Ensure we are in physics
+	var space_state: PhysicsDirectSpaceState3D = PhysicsServer3D.space_get_direct_state(domain.space_state_rid)
 	var hit
 	var d: float
 	var t: Transform3D
@@ -98,6 +100,7 @@ func _process_transforms(transforms, domain, _seed) -> void:
 	var remapped_max_slope = remap(max_slope, 0.0, 90.0, 0.0, 1.0)
 	var is_point_valid := false
 
+#	domain.space_state= domain.root.get_world_3d().get_direct_space_state()
 	while i < transforms.size():
 		t = transforms.list[i]
 		is_point_valid = true

--- a/src/presets/preset_entry.gd
+++ b/src/presets/preset_entry.gd
@@ -1,5 +1,5 @@
 @tool
-extends MarginContainer
+class_name PresetEntry extends MarginContainer
 
 signal load_full
 signal load_stack_only

--- a/src/presets/preset_entry.tscn
+++ b/src/presets/preset_entry.tscn
@@ -2,13 +2,12 @@
 
 [ext_resource type="Texture2D" uid="uid://ddjrq1h4mkn6a" path="res://addons/proton_scatter/icons/load.svg" id="1_0auay"]
 [ext_resource type="Script" path="res://addons/proton_scatter/src/presets/preset_entry.gd" id="1_bqha3"]
-[ext_resource type="Texture2D" uid="uid://bl1rkjjxvxu8f" path="res://addons/proton_scatter/icons/remove.svg" id="2_p04k2"]
+[ext_resource type="Texture2D" uid="uid://bogrw12deh3i7" path="res://addons/proton_scatter/icons/remove.svg" id="2_p04k2"]
 
-[sub_resource type="SystemFont" id="SystemFont_kgkwq"]
-font_style = 1
+[sub_resource type="SystemFont" id="SystemFont_yfwuv"]
 
-[sub_resource type="LabelSettings" id="LabelSettings_poli7"]
-font = SubResource("SystemFont_kgkwq")
+[sub_resource type="LabelSettings" id="LabelSettings_cuox3"]
+font = SubResource("SystemFont_yfwuv")
 
 [node name="PresetEntry" type="MarginContainer"]
 custom_minimum_size = Vector2(450, 0)
@@ -25,13 +24,9 @@ script = ExtResource("1_bqha3")
 
 [node name="Panel" type="Panel" parent="."]
 layout_mode = 2
-offset_right = 1920.0
-offset_bottom = 90.0
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2
-offset_right = 1920.0
-offset_bottom = 90.0
 theme_override_constants/margin_left = 12
 theme_override_constants/margin_top = 12
 theme_override_constants/margin_right = 12
@@ -39,40 +34,25 @@ theme_override_constants/margin_bottom = 12
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer"]
 layout_mode = 2
-offset_left = 12.0
-offset_top = 12.0
-offset_right = 1908.0
-offset_bottom = 78.0
 
 [node name="Label" type="Label" parent="MarginContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_top = 20.0
-offset_right = 1669.0
-offset_bottom = 46.0
 size_flags_horizontal = 3
 text = "Preset name"
-label_settings = SubResource("LabelSettings_poli7")
+label_settings = SubResource("LabelSettings_cuox3")
 
 [node name="VSeparator" type="VSeparator" parent="MarginContainer/HBoxContainer"]
 layout_mode = 2
-offset_left = 1673.0
-offset_right = 1677.0
-offset_bottom = 66.0
 
 [node name="LoadButtons" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 1681.0
-offset_right = 1860.0
-offset_bottom = 66.0
 alignment = 1
 
 [node name="LoadStackOnly" type="Button" parent="MarginContainer/HBoxContainer/LoadButtons"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 179.0
-offset_bottom = 31.0
 text = "Load modifier stack"
 icon = ExtResource("1_0auay")
 alignment = 0
@@ -80,9 +60,6 @@ alignment = 0
 [node name="LoadFullPreset" type="Button" parent="MarginContainer/HBoxContainer/LoadButtons"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_top = 35.0
-offset_right = 179.0
-offset_bottom = 66.0
 text = "Load full preset"
 icon = ExtResource("1_0auay")
 alignment = 0
@@ -91,40 +68,25 @@ alignment = 0
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
-offset_left = 1712.0
-offset_right = 1860.0
-offset_bottom = 96.0
 size_flags_stretch_ratio = 2.0
 alignment = 1
 
 [node name="OverrideButton" type="Button" parent="MarginContainer/HBoxContainer/SaveButtons"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_top = 32.0
-offset_right = 148.0
-offset_bottom = 63.0
 text = "Override preset"
 icon = ExtResource("1_0auay")
 alignment = 0
 
 [node name="VSeparator2" type="VSeparator" parent="MarginContainer/HBoxContainer"]
 layout_mode = 2
-offset_left = 1864.0
-offset_right = 1868.0
-offset_bottom = 66.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
 layout_mode = 2
-offset_left = 1872.0
-offset_right = 1896.0
-offset_bottom = 66.0
 alignment = 1
 
 [node name="DeleteButton" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_top = 21.0
-offset_right = 24.0
-offset_bottom = 45.0
 theme_override_colors/icon_normal_color = Color(0.917647, 0.0784314, 0, 1)
 icon = ExtResource("2_p04k2")

--- a/src/presets/presets.gd
+++ b/src/presets/presets.gd
@@ -3,10 +3,10 @@ extends Popup
 
 
 const PRESETS_PATH = "res://addons/proton_scatter/presets"
-const PresetEntry := preload("./preset_entry.tscn")
-const ScatterUtil := preload('../common/scatter_util.gd')
-const ScatterItem := preload('../scatter_item.gd')
-const ScatterShape := preload('../scatter_shape.gd')
+const PresetEntryNode := preload("./preset_entry.tscn")
+#const ScatterUtil := preload('../common/scatter_util.gd')
+#const ScatterItem := preload('../scatter_item.gd')
+#const ScatterShape := preload('../scatter_shape.gd')
 
 var _scatter_node
 var _ideal_popup_size: Vector2i
@@ -86,7 +86,7 @@ func _populate() -> void:
 
 		# Preset found, create an entry
 		var full_path = PRESETS_PATH.path_join(file)
-		var entry := PresetEntry.instantiate()
+		var entry := PresetEntryNode.instantiate()
 		entry.set_preset_name(file.get_basename())
 		entry.load_full.connect(_on_load_full_preset.bind(full_path))
 		entry.load_stack_only.connect(_on_load_stack_only.bind(full_path))

--- a/src/scatter.gd
+++ b/src/scatter.gd
@@ -1,17 +1,17 @@
 @tool
-extends Node3D
+class_name Scatter extends Node3D
 
 
 signal shape_changed
 signal thread_completed
 signal build_completed
 
-const ScatterUtil := preload('./common/scatter_util.gd')
-const ModifierStack := preload("./stack/modifier_stack.gd")
-const TransformList := preload("res://addons/proton_scatter/src/common/transform_list.gd")
-const ScatterItem := preload("./scatter_item.gd")
-const ScatterShape := preload("./scatter_shape.gd")
-const Domain := preload("./common/domain.gd")
+#const ScatterUtil := preload('./common/scatter_util.gd')
+#const ModifierStack := preload("./stack/modifier_stack.gd")
+#const TransformList := preload("res://addons/proton_scatter/src/common/transform_list.gd")
+#const ScatterItem := preload("./scatter_item.gd")
+#const ScatterShape := preload("./scatter_shape.gd")
+#const Domain := preload("./common/domain.gd")
 
 
 @export_category("ProtonScatter")
@@ -349,10 +349,16 @@ func _create_instance(item: ScatterItem, root: Node3D):
 		return null
 
 	var instance = item.get_item().duplicate()
-	root.add_child.bind(instance, true).call_deferred()
-	instance.set_owner(get_tree().get_edited_scene_root())
 	instance.visible = true
-	ScatterUtil.set_owner_recursive(instance, get_tree().get_edited_scene_root())
+	root.add_child.bind(instance, true).call_deferred()
+	instance.set_owner.bind(get_tree().get_edited_scene_root()).call_deferred()
+	var defer_ownership := func(inst,ownership):
+		ScatterUtil.set_owner_recursive(instance, ownership)
+	defer_ownership.bind(instance,get_tree().get_edited_scene_root()).call_deferred()
+
+
+
+#	ScatterUtil.set_owner_recursive(instance, get_tree().get_edited_scene_root())
 
 	return instance
 

--- a/src/scatter_gizmo_plugin.gd
+++ b/src/scatter_gizmo_plugin.gd
@@ -1,5 +1,5 @@
 @tool
-extends EditorNode3DGizmoPlugin
+class_name ScatterGizmoPlugin extends EditorNode3DGizmoPlugin
 
 
 #

--- a/src/scatter_item.gd
+++ b/src/scatter_item.gd
@@ -1,8 +1,8 @@
 @tool
-extends Node3D
+class_name ScatterItem extends Node3D
 
 
-const ScatterUtil := preload('./common/scatter_util.gd')
+#const ScatterUtil := preload('./common/scatter_util.gd')
 
 
 @export_category("ScatterItem")

--- a/src/scatter_shape.gd
+++ b/src/scatter_shape.gd
@@ -1,8 +1,8 @@
 @tool
-extends Node3D
+class_name ScatterShape extends Node3D
 
 
-const ScatterUtil := preload('./common/scatter_util.gd')
+#const ScatterUtil := preload('./common/scatter_util.gd')
 
 
 @export_category("ScatterShape")

--- a/src/shapes/base_shape.gd
+++ b/src/shapes/base_shape.gd
@@ -1,6 +1,5 @@
 @tool
-class_name ProtonScatterBaseShape
-extends Resource
+class_name ProtonScatterBaseShape extends Resource
 
 
 func is_point_inside(point_global: Vector3, global_transform: Transform3D) -> bool:

--- a/src/shapes/gizmos_plugin/box_gizmo.gd
+++ b/src/shapes/gizmos_plugin/box_gizmo.gd
@@ -1,5 +1,5 @@
 @tool
-extends "gizmo_handler.gd"
+class_name BoxGizmo extends GizmoHandler
 
 # 3D Gizmo for the Box shape.
 

--- a/src/shapes/gizmos_plugin/components/path_advanced_options_panel.tscn
+++ b/src/shapes/gizmos_plugin/components/path_advanced_options_panel.tscn
@@ -9,47 +9,34 @@ size_flags_vertical = 4
 metadata/_edit_use_custom_anchors = true
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
-offset_right = 221.0
-offset_bottom = 136.0
+layout_mode = 2
 
 [node name="VBoxContainer" type="VBoxContainer" parent="HBoxContainer"]
-offset_right = 217.0
-offset_bottom = 136.0
+layout_mode = 2
 
 [node name="MirrorLength" type="CheckButton" parent="HBoxContainer/VBoxContainer"]
-offset_right = 217.0
-offset_bottom = 31.0
+layout_mode = 2
 focus_mode = 0
 text = "Mirror handles length"
 
 [node name="MirrorAngle" type="CheckButton" parent="HBoxContainer/VBoxContainer"]
-offset_top = 35.0
-offset_right = 217.0
-offset_bottom = 66.0
+layout_mode = 2
 focus_mode = 0
 text = "Mirror handles angle"
 
 [node name="LockToPlane" type="CheckButton" parent="HBoxContainer/VBoxContainer"]
-offset_top = 70.0
-offset_right = 217.0
-offset_bottom = 101.0
+layout_mode = 2
 focus_mode = 0
 text = "Lock to plane"
 
 [node name="MirrorAngle3" type="CheckButton" parent="HBoxContainer/VBoxContainer"]
-offset_top = 105.0
-offset_right = 217.0
-offset_bottom = 136.0
+layout_mode = 2
 focus_mode = 0
 text = "Snap to colliders"
 
 [node name="VSeparator" type="VSeparator" parent="HBoxContainer"]
 visible = false
-offset_left = 221.0
-offset_right = 225.0
-offset_bottom = 136.0
+layout_mode = 2
 
 [node name="VBoxContainer2" type="VBoxContainer" parent="HBoxContainer"]
-offset_left = 221.0
-offset_right = 221.0
-offset_bottom = 136.0
+layout_mode = 2

--- a/src/shapes/gizmos_plugin/components/path_panel.gd
+++ b/src/shapes/gizmos_plugin/components/path_panel.gd
@@ -1,22 +1,22 @@
 @tool
-extends Control
+class_name PathPanel extends Control
 
 
-const ScatterShape = preload("../../../scatter_shape.gd")
-const PathShape = preload("../../path_shape.gd")
+#const ScatterShape = preload("../../../scatter_shape.gd")
+#const ProtonScatterPathShape = preload("../../path_shape.gd")
 
 var shape_node: ScatterShape
-
-@onready var _options_button: Button = $%Options
-@onready var _options_panel: Popup = $%OptionsPanel
+#
+#@onready var _options_button:= $%Options
+#@onready var _options_panel:= $%OptionsPanel
 
 
 func _ready() -> void:
-	_options_button.toggled.connect(_on_options_button_toggled)
-	_options_panel.popup_hide.connect(_on_options_panel_hide)
 	$%SnapToColliders.toggled.connect(_on_snap_to_colliders_toggled)
 	$%ClosedPath.toggled.connect(_on_closed_path_toggled)
 	$%MirrorAngle.toggled.connect(_on_mirror_angle_toggled)
+	$%OptionsButton.toggled.connect(_on_options_button_toggled)
+	$%OptionsPanel.popup_hide.connect(_on_options_panel_hide)
 
 	for button in [$%LockToPlane, $%SnapToColliders, $%ClosedPath]:
 		button.pressed.connect(_on_button_pressed)
@@ -31,7 +31,7 @@ func selection_changed(selected: Array) -> void:
 		return
 
 	var node = selected[0]
-	visible = node is ScatterShape and node.shape is PathShape
+	visible = node is ScatterShape and node.shape is ProtonScatterPathShape
 	if visible:
 		shape_node = node
 		$%ClosedPath.button_pressed = node.shape.closed
@@ -69,13 +69,13 @@ func _on_options_button_toggled(enabled: bool) -> void:
 	if enabled:
 		var popup_position := Vector2i(get_global_transform().origin)
 		popup_position.y += size.y + 12
-		_options_panel.popup(Rect2i(popup_position, Vector2i.ZERO))
+		$%OptionsPanel.popup(Rect2i(popup_position, Vector2i.ZERO))
 	else:
-		_options_panel.hide()
+		$%OptionsPanel.hide()
 
 
 func _on_options_panel_hide() -> void:
-	_options_button.button_pressed = false
+	$%OptionsButton.button_pressed = false
 
 
 func _on_mirror_angle_toggled(enabled: bool) -> void:
@@ -87,7 +87,7 @@ func _on_snap_to_colliders_toggled(enabled: bool) -> void:
 
 
 func _on_closed_path_toggled(enabled: bool) -> void:
-	if shape_node and shape_node.shape is PathShape:
+	if shape_node and shape_node.shape is ProtonScatterPathShape:
 		shape_node.shape.closed = enabled
 
 

--- a/src/shapes/gizmos_plugin/components/path_panel.tscn
+++ b/src/shapes/gizmos_plugin/components/path_panel.tscn
@@ -1,10 +1,7 @@
-[gd_scene load_steps=7 format=3 uid="uid://vijpujrvtyin"]
+[gd_scene load_steps=4 format=3 uid="uid://vijpujrvtyin"]
 
 [ext_resource type="Script" path="res://addons/proton_scatter/src/shapes/gizmos_plugin/components/path_panel.gd" id="1_o7kkg"]
-[ext_resource type="Texture2D" uid="uid://b2b62ko7v686h" path="res://addons/proton_scatter/icons/curve_select.svg" id="2_d7o1n"]
 [ext_resource type="ButtonGroup" uid="uid://1xy55037k3k5" path="res://addons/proton_scatter/src/shapes/gizmos_plugin/components/curve_mode_button_group.tres" id="2_sl6yo"]
-[ext_resource type="Texture2D" uid="uid://c31odatai1367" path="res://addons/proton_scatter/icons/curve_create.svg" id="3_l70sn"]
-[ext_resource type="Texture2D" uid="uid://pog84tx0x6ka" path="res://addons/proton_scatter/icons/curve_delete.svg" id="4_b5yum"]
 [ext_resource type="Texture2D" uid="uid://n66mufjib4ds" path="res://addons/proton_scatter/icons/menu.svg" id="6_xiaj2"]
 
 [node name="PathPanel" type="MarginContainer"]
@@ -16,61 +13,43 @@ script = ExtResource("1_o7kkg")
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
 layout_mode = 2
-offset_right = 108.0
-offset_bottom = 24.0
 size_flags_horizontal = 4
 size_flags_vertical = 4
 
 [node name="HBoxContainer" type="HBoxContainer" parent="HBoxContainer"]
 layout_mode = 2
-offset_right = 80.0
-offset_bottom = 24.0
 
 [node name="Select" type="Button" parent="HBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 24.0
-offset_bottom = 24.0
 focus_mode = 0
 toggle_mode = true
 button_pressed = true
 button_group = ExtResource("2_sl6yo")
-icon = ExtResource("2_d7o1n")
 flat = true
 icon_alignment = 1
 
 [node name="Create" type="Button" parent="HBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 28.0
-offset_right = 52.0
-offset_bottom = 24.0
 focus_mode = 0
 toggle_mode = true
 button_group = ExtResource("2_sl6yo")
-icon = ExtResource("3_l70sn")
 flat = true
 icon_alignment = 1
 
 [node name="Delete" type="Button" parent="HBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 56.0
-offset_right = 80.0
-offset_bottom = 24.0
 focus_mode = 0
 toggle_mode = true
 button_group = ExtResource("2_sl6yo")
-icon = ExtResource("4_b5yum")
 flat = true
 icon_alignment = 1
 
-[node name="Options" type="Button" parent="HBoxContainer"]
+[node name="OptionsButton" type="Button" parent="HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 84.0
-offset_right = 108.0
-offset_bottom = 24.0
 focus_mode = 0
 toggle_mode = true
 action_mode = 0
@@ -94,19 +73,13 @@ metadata/_edit_use_custom_anchors = true
 
 [node name="HBoxContainer" type="HBoxContainer" parent="OptionsPanel/AdvancedOptionsPanel"]
 layout_mode = 2
-offset_right = 221.0
-offset_bottom = 171.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="OptionsPanel/AdvancedOptionsPanel/HBoxContainer"]
 layout_mode = 2
-offset_right = 217.0
-offset_bottom = 171.0
 
 [node name="MirrorAngle" type="CheckButton" parent="OptionsPanel/AdvancedOptionsPanel/HBoxContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 217.0
-offset_bottom = 31.0
 focus_mode = 0
 button_pressed = true
 text = "Mirror handles angle"
@@ -114,9 +87,6 @@ text = "Mirror handles angle"
 [node name="MirrorLength" type="CheckButton" parent="OptionsPanel/AdvancedOptionsPanel/HBoxContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_top = 35.0
-offset_right = 217.0
-offset_bottom = 66.0
 focus_mode = 0
 button_pressed = true
 text = "Mirror handles length"
@@ -124,18 +94,12 @@ text = "Mirror handles length"
 [node name="ClosedPath" type="CheckButton" parent="OptionsPanel/AdvancedOptionsPanel/HBoxContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_top = 70.0
-offset_right = 217.0
-offset_bottom = 101.0
 focus_mode = 0
 text = "Closed path"
 
 [node name="LockToPlane" type="CheckButton" parent="OptionsPanel/AdvancedOptionsPanel/HBoxContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_top = 105.0
-offset_right = 217.0
-offset_bottom = 136.0
 focus_mode = 0
 button_pressed = true
 text = "Lock to plane"
@@ -143,21 +107,12 @@ text = "Lock to plane"
 [node name="SnapToColliders" type="CheckButton" parent="OptionsPanel/AdvancedOptionsPanel/HBoxContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_top = 140.0
-offset_right = 217.0
-offset_bottom = 171.0
 focus_mode = 0
 text = "Snap to colliders"
 
 [node name="VSeparator" type="VSeparator" parent="OptionsPanel/AdvancedOptionsPanel/HBoxContainer"]
 visible = false
 layout_mode = 2
-offset_left = 221.0
-offset_right = 225.0
-offset_bottom = 136.0
 
 [node name="VBoxContainer2" type="VBoxContainer" parent="OptionsPanel/AdvancedOptionsPanel/HBoxContainer"]
 layout_mode = 2
-offset_left = 221.0
-offset_right = 221.0
-offset_bottom = 171.0

--- a/src/shapes/gizmos_plugin/gizmo_handler.gd
+++ b/src/shapes/gizmos_plugin/gizmo_handler.gd
@@ -1,5 +1,5 @@
 @tool
-extends RefCounted
+class_name GizmoHandler extends RefCounted
 
 # Abstract class.
 

--- a/src/shapes/gizmos_plugin/path_gizmo.gd
+++ b/src/shapes/gizmos_plugin/path_gizmo.gd
@@ -1,10 +1,10 @@
 @tool
-extends "gizmo_handler.gd"
+class_name PathGizmo extends GizmoHandler
 
 
-const ScatterShape = preload("../../scatter_shape.gd")
-const PathPanel = preload("./components/path_panel.gd")
-const EventUtil = preload("../../common/event_util.gd")
+#const ScatterShape = preload("../../scatter_shape.gd")
+#const PathPanel = preload("./components/path_panel.gd")
+#const EventUtil = preload("../../common/event_util.gd")
 
 var _gizmo_panel: PathPanel
 var _event_util: EventUtil

--- a/src/shapes/gizmos_plugin/shape_gizmo_plugin.gd
+++ b/src/shapes/gizmos_plugin/shape_gizmo_plugin.gd
@@ -1,5 +1,5 @@
 @tool
-extends EditorNode3DGizmoPlugin
+class_name ShapeGizmoPlugin extends EditorNode3DGizmoPlugin
 
 
 # Actual logic split in the handler class to avoid cluttering this script as
@@ -10,8 +10,8 @@ extends EditorNode3DGizmoPlugin
 # than it's worth (2 fewer files), so it's done like this instead.
 
 
-const ScatterShape = preload("../../scatter_shape.gd")
-const GizmoHandler = preload("./gizmo_handler.gd")
+#const ScatterShape = preload("../../scatter_shape.gd")
+#const GizmoHandler = preload("./gizmo_handler.gd")
 
 var _handlers: Dictionary
 
@@ -35,9 +35,9 @@ func _init():
 	create_handle_material("primary_handle", false, handle_icon)
 	create_handle_material("secondary_handle", false, secondary_handle_icon)
 
-	_handlers[ProtonScatterSphereShape] = preload("./sphere_gizmo.gd").new()
-	_handlers[ProtonScatterPathShape] = preload("./path_gizmo.gd").new()
-	_handlers[ProtonScatterBoxShape] = preload("./box_gizmo.gd").new()
+	_handlers[ProtonScatterSphereShape] = SphereGizmo.new()
+	_handlers[ProtonScatterPathShape] = PathGizmo.new()
+	_handlers[ProtonScatterBoxShape] = BoxGizmo.new()
 
 
 func _get_gizmo_name() -> String:

--- a/src/shapes/gizmos_plugin/sphere_gizmo.gd
+++ b/src/shapes/gizmos_plugin/sphere_gizmo.gd
@@ -1,12 +1,12 @@
 @tool
-extends "gizmo_handler.gd"
+class_name SphereGizmo extends GizmoHandler
 
 # 3D Gizmo for the Sphere shape. Draws three circle on each axis to represent
 # a sphere, displays one handle on the size to control the radius.
 #
 # (handle_id is ignored in every function since there's a single handle)
 
-const SphereShape = preload("../sphere_shape.gd")
+#const ProtonScatterSphereShape = preload("../sphere_shape.gd")
 
 
 func get_handle_name(_gizmo: EditorNode3DGizmo, _handle_id: int, _secondary: bool) -> String:
@@ -30,7 +30,7 @@ func set_handle(gizmo: EditorNode3DGizmo, _handle_id: int, _secondary: bool, cam
 
 
 func commit_handle(gizmo: EditorNode3DGizmo, _handle_id: int, _secondary: bool, restore: Variant, cancel: bool) -> void:
-	var shape: SphereShape = gizmo.get_node_3d().shape
+	var shape: ProtonScatterSphereShape = gizmo.get_node_3d().shape
 	if cancel:
 		shape.radius = restore
 		return
@@ -44,7 +44,7 @@ func commit_handle(gizmo: EditorNode3DGizmo, _handle_id: int, _secondary: bool, 
 func redraw(plugin: EditorNode3DGizmoPlugin, gizmo: EditorNode3DGizmo):
 	gizmo.clear()
 	var scatter_shape = gizmo.get_node_3d()
-	var shape: SphereShape = scatter_shape.shape
+	var shape: ProtonScatterSphereShape = scatter_shape.shape
 
 	### Draw the 3 circles on each axis to represent the sphere
 	var lines = PackedVector3Array()
@@ -91,6 +91,6 @@ func redraw(plugin: EditorNode3DGizmoPlugin, gizmo: EditorNode3DGizmo):
 	gizmo.add_mesh(mesh, mesh_material)
 
 
-func _set_radius(sphere: SphereShape, radius: float) -> void:
+func _set_radius(sphere: ProtonScatterSphereShape, radius: float) -> void:
 	if sphere:
 		sphere.radius = radius

--- a/src/shapes/path_shape.gd
+++ b/src/shapes/path_shape.gd
@@ -3,7 +3,7 @@ class_name ProtonScatterPathShape
 extends ProtonScatterBaseShape
 
 
-const Bounds := preload("../common/bounds.gd")
+#const Bounds := preload("../common/bounds.gd")
 
 
 @export var closed := true:

--- a/src/stack/inspector_plugin/editor_property.gd
+++ b/src/stack/inspector_plugin/editor_property.gd
@@ -1,5 +1,5 @@
 @tool
-extends EditorProperty
+class_name Editor extends EditorProperty
 
 
 var _ui: Control

--- a/src/stack/inspector_plugin/modifier_stack_plugin.gd
+++ b/src/stack/inspector_plugin/modifier_stack_plugin.gd
@@ -1,9 +1,9 @@
 @tool
-extends EditorInspectorPlugin
+class_name ModifierStackPlugin extends EditorInspectorPlugin
 
 
-const Editor = preload("./editor_property.gd")
-const Scatter = preload("../../scatter.gd")
+#const Editor = preload("./editor_property.gd")
+#const Scatter = preload("../../scatter.gd")
 
 
 func _can_handle(object):
@@ -12,7 +12,7 @@ func _can_handle(object):
 
 func _parse_property(object, type, name, hint_type, hint_string, usage_flags, wide):
 	if name == "modifier_stack":
-		var editor_property = Editor.new()
+		var editor_property := Editor.new()
 		editor_property.set_node(object)
 		add_property_editor("modifier_stack", editor_property)
 		return true

--- a/src/stack/inspector_plugin/ui/modifier/components/base_parameter.gd
+++ b/src/stack/inspector_plugin/ui/modifier/components/base_parameter.gd
@@ -1,5 +1,5 @@
 @tool
-extends Control
+class_name BaseParameter extends Control
 
 
 signal value_changed

--- a/src/stack/inspector_plugin/ui/modifier/components/header/parameter_button.gd
+++ b/src/stack/inspector_plugin/ui/modifier/components/header/parameter_button.gd
@@ -1,5 +1,5 @@
 @tool
-extends "../base_parameter.gd"
+class_name ParameterButton extends BaseParameter
 
 
 var _button

--- a/src/stack/inspector_plugin/ui/modifier/components/parameter_bitmask.gd
+++ b/src/stack/inspector_plugin/ui/modifier/components/parameter_bitmask.gd
@@ -1,5 +1,5 @@
 @tool
-extends "base_parameter.gd"
+class_name ParameterBitmask extends BaseParameter
 
 
 @onready var _label: Label = $Label

--- a/src/stack/inspector_plugin/ui/modifier/components/parameter_bitmask.tscn
+++ b/src/stack/inspector_plugin/ui/modifier/components/parameter_bitmask.tscn
@@ -4,39 +4,34 @@
 [ext_resource type="PackedScene" uid="uid://cf4lrr5tnlwnw" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier/components/bitmask_button.tscn" id="2"]
 [ext_resource type="Texture2D" uid="uid://n66mufjib4ds" path="res://addons/proton_scatter/icons/menu.svg" id="3"]
 [ext_resource type="Texture2D" uid="uid://bosx22dy64f11" path="res://addons/proton_scatter/icons/clear.svg" id="4"]
-[ext_resource type="Texture2D" uid="uid://bb6107shgmiaw" path="res://addons/proton_scatter/icons/select_all.svg" id="4_h30jm"]
+[ext_resource type="Texture2D" uid="uid://c027p8qhvdaoy" path="res://addons/proton_scatter/icons/select_all.svg" id="4_h30jm"]
 
 [node name="parameter_bitmask" type="VBoxContainer"]
+anchors_preset = 10
 anchor_right = 1.0
 offset_bottom = 178.0
 script = ExtResource("1")
 
 [node name="Label" type="Label" parent="."]
-offset_right = 1024.0
-offset_bottom = 26.0
+layout_mode = 2
 text = "Parameter name"
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
-offset_top = 30.0
-offset_right = 1024.0
-offset_bottom = 130.0
+layout_mode = 2
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer"]
-offset_right = 1024.0
-offset_bottom = 100.0
+layout_mode = 2
 alignment = 2
 
 [node name="MenuButton" type="MenuButton" parent="MarginContainer/HBoxContainer"]
 unique_name_in_owner = true
-offset_left = 772.0
-offset_right = 796.0
-offset_bottom = 100.0
+layout_mode = 2
 icon = ExtResource("3")
 item_count = 39
-popup/item_0/text = "Layer 1"
+popup/item_0/text = "Environment"
 popup/item_0/checkable = 1
 popup/item_0/id = 31
-popup/item_1/text = "Layer 2"
+popup/item_1/text = "Pawn"
 popup/item_1/checkable = 1
 popup/item_1/id = 30
 popup/item_2/text = "Layer 3"
@@ -152,282 +147,186 @@ popup/item_38/checkable = 1
 popup/item_38/id = 0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
-offset_left = 800.0
-offset_right = 996.0
-offset_bottom = 100.0
+layout_mode = 2
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/HBoxContainer/VBoxContainer"]
-offset_right = 196.0
-offset_bottom = 44.0
+layout_mode = 2
 
 [node name="GridContainer1" type="GridContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
-offset_right = 92.0
-offset_bottom = 44.0
+layout_mode = 2
 columns = 4
 
 [node name="Button1" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/GridContainer1" instance=ExtResource("2")]
-offset_right = 20.0
-offset_bottom = 20.0
+layout_mode = 2
 text = "1"
 
 [node name="Button2" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/GridContainer1" instance=ExtResource("2")]
-offset_left = 24.0
-offset_right = 44.0
-offset_bottom = 20.0
+layout_mode = 2
 text = "2"
 
 [node name="Button3" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/GridContainer1" instance=ExtResource("2")]
-offset_left = 48.0
-offset_right = 68.0
-offset_bottom = 20.0
+layout_mode = 2
 text = "3"
 
 [node name="Button4" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/GridContainer1" instance=ExtResource("2")]
-offset_left = 72.0
-offset_right = 92.0
-offset_bottom = 20.0
+layout_mode = 2
 text = "4"
 
 [node name="Button5" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/GridContainer1" instance=ExtResource("2")]
-offset_top = 24.0
-offset_right = 20.0
-offset_bottom = 44.0
+layout_mode = 2
 text = "5"
 
 [node name="Button6" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/GridContainer1" instance=ExtResource("2")]
-offset_left = 24.0
-offset_top = 24.0
-offset_right = 44.0
-offset_bottom = 44.0
+layout_mode = 2
 text = "6"
 
 [node name="Button7" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/GridContainer1" instance=ExtResource("2")]
-offset_left = 48.0
-offset_top = 24.0
-offset_right = 68.0
-offset_bottom = 44.0
+layout_mode = 2
 text = "7"
 
 [node name="Button8" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/GridContainer1" instance=ExtResource("2")]
-offset_left = 72.0
-offset_top = 24.0
-offset_right = 92.0
-offset_bottom = 44.0
+layout_mode = 2
 text = "8"
 
 [node name="VSeparator" type="VSeparator" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer"]
-offset_left = 96.0
-offset_right = 100.0
-offset_bottom = 44.0
+layout_mode = 2
 
 [node name="GridContainer2" type="GridContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
-offset_left = 104.0
-offset_right = 196.0
-offset_bottom = 44.0
+layout_mode = 2
 columns = 4
 
 [node name="Button9" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/GridContainer2" instance=ExtResource("2")]
-offset_right = 20.0
-offset_bottom = 20.0
+layout_mode = 2
 text = "9"
 
 [node name="Button10" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/GridContainer2" instance=ExtResource("2")]
-offset_left = 24.0
-offset_right = 44.0
-offset_bottom = 20.0
+layout_mode = 2
 text = "10"
 
 [node name="Button11" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/GridContainer2" instance=ExtResource("2")]
-offset_left = 48.0
-offset_right = 68.0
-offset_bottom = 20.0
+layout_mode = 2
 text = "11"
 
 [node name="Button12" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/GridContainer2" instance=ExtResource("2")]
-offset_left = 72.0
-offset_right = 92.0
-offset_bottom = 20.0
+layout_mode = 2
 text = "12"
 
 [node name="Button13" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/GridContainer2" instance=ExtResource("2")]
-offset_top = 24.0
-offset_right = 20.0
-offset_bottom = 44.0
+layout_mode = 2
 text = "13"
 
 [node name="Button14" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/GridContainer2" instance=ExtResource("2")]
-offset_left = 24.0
-offset_top = 24.0
-offset_right = 44.0
-offset_bottom = 44.0
+layout_mode = 2
 text = "14"
 
 [node name="Button15" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/GridContainer2" instance=ExtResource("2")]
-offset_left = 48.0
-offset_top = 24.0
-offset_right = 68.0
-offset_bottom = 44.0
+layout_mode = 2
 text = "15"
 
 [node name="Button16" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer/GridContainer2" instance=ExtResource("2")]
-offset_left = 72.0
-offset_top = 24.0
-offset_right = 92.0
-offset_bottom = 44.0
+layout_mode = 2
 text = "16"
 
 [node name="HSeparator" type="HSeparator" parent="MarginContainer/HBoxContainer/VBoxContainer"]
-offset_top = 48.0
-offset_right = 196.0
-offset_bottom = 52.0
+layout_mode = 2
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="MarginContainer/HBoxContainer/VBoxContainer"]
-offset_top = 56.0
-offset_right = 196.0
-offset_bottom = 100.0
+layout_mode = 2
 
 [node name="GridContainer3" type="GridContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2"]
 unique_name_in_owner = true
-offset_right = 92.0
-offset_bottom = 44.0
+layout_mode = 2
 columns = 4
 
 [node name="Button17" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2/GridContainer3" instance=ExtResource("2")]
-offset_right = 20.0
-offset_bottom = 20.0
+layout_mode = 2
 text = "17"
 
 [node name="Button18" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2/GridContainer3" instance=ExtResource("2")]
-offset_left = 24.0
-offset_right = 44.0
-offset_bottom = 20.0
+layout_mode = 2
 text = "18"
 
 [node name="Button19" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2/GridContainer3" instance=ExtResource("2")]
-offset_left = 48.0
-offset_right = 68.0
-offset_bottom = 20.0
+layout_mode = 2
 text = "19"
 
 [node name="Button20" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2/GridContainer3" instance=ExtResource("2")]
-offset_left = 72.0
-offset_right = 92.0
-offset_bottom = 20.0
+layout_mode = 2
 text = "20"
 
 [node name="Button21" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2/GridContainer3" instance=ExtResource("2")]
-offset_top = 24.0
-offset_right = 20.0
-offset_bottom = 44.0
+layout_mode = 2
 text = "21"
 
 [node name="Button22" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2/GridContainer3" instance=ExtResource("2")]
-offset_left = 24.0
-offset_top = 24.0
-offset_right = 44.0
-offset_bottom = 44.0
+layout_mode = 2
 text = "22"
 
 [node name="Button23" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2/GridContainer3" instance=ExtResource("2")]
-offset_left = 48.0
-offset_top = 24.0
-offset_right = 68.0
-offset_bottom = 44.0
+layout_mode = 2
 text = "23"
 
 [node name="Button24" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2/GridContainer3" instance=ExtResource("2")]
-offset_left = 72.0
-offset_top = 24.0
-offset_right = 92.0
-offset_bottom = 44.0
+layout_mode = 2
 text = "24"
 
 [node name="VSeparator2" type="VSeparator" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2"]
-offset_left = 96.0
-offset_right = 100.0
-offset_bottom = 44.0
+layout_mode = 2
 
 [node name="GridContainer4" type="GridContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2"]
 unique_name_in_owner = true
-offset_left = 104.0
-offset_right = 196.0
-offset_bottom = 44.0
+layout_mode = 2
 columns = 4
 
 [node name="Button25" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2/GridContainer4" instance=ExtResource("2")]
-offset_right = 20.0
-offset_bottom = 20.0
+layout_mode = 2
 text = "25"
 
 [node name="Button26" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2/GridContainer4" instance=ExtResource("2")]
-offset_left = 24.0
-offset_right = 44.0
-offset_bottom = 20.0
+layout_mode = 2
 text = "26"
 
 [node name="Button27" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2/GridContainer4" instance=ExtResource("2")]
-offset_left = 48.0
-offset_right = 68.0
-offset_bottom = 20.0
+layout_mode = 2
 text = "27"
 
 [node name="Button28" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2/GridContainer4" instance=ExtResource("2")]
-offset_left = 72.0
-offset_right = 92.0
-offset_bottom = 20.0
+layout_mode = 2
 text = "28"
 
 [node name="Button29" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2/GridContainer4" instance=ExtResource("2")]
-offset_top = 24.0
-offset_right = 20.0
-offset_bottom = 44.0
+layout_mode = 2
 text = "29"
 
 [node name="Button30" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2/GridContainer4" instance=ExtResource("2")]
-offset_left = 24.0
-offset_top = 24.0
-offset_right = 44.0
-offset_bottom = 44.0
+layout_mode = 2
 text = "30"
 
 [node name="Button31" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2/GridContainer4" instance=ExtResource("2")]
-offset_left = 48.0
-offset_top = 24.0
-offset_right = 68.0
-offset_bottom = 44.0
+layout_mode = 2
 text = "31"
 
 [node name="Button32" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2/GridContainer4" instance=ExtResource("2")]
-offset_left = 72.0
-offset_top = 24.0
-offset_right = 92.0
-offset_bottom = 44.0
+layout_mode = 2
 text = "32"
 
 [node name="VBoxContainer2" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
-offset_left = 1000.0
-offset_right = 1024.0
-offset_bottom = 100.0
+layout_mode = 2
 alignment = 1
 
 [node name="EnableAll" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer2"]
-offset_right = 24.0
-offset_bottom = 48.0
+layout_mode = 2
 size_flags_vertical = 3
-hint_tooltip = "Enable all layers"
 focus_mode = 0
 icon = ExtResource("4_h30jm")
 flat = true
 expand_icon = true
 
 [node name="ClearButton" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer2"]
-offset_top = 52.0
-offset_right = 24.0
-offset_bottom = 100.0
+layout_mode = 2
 size_flags_vertical = 3
-hint_tooltip = "Clear all layers"
 focus_mode = 0
 icon = ExtResource("4")
 flat = true

--- a/src/stack/inspector_plugin/ui/modifier/components/parameter_bool.gd
+++ b/src/stack/inspector_plugin/ui/modifier/components/parameter_bool.gd
@@ -1,5 +1,5 @@
 @tool
-extends "base_parameter.gd"
+class_name ParameterBool extends BaseParameter
 
 
 @onready var _label: Label = $Label

--- a/src/stack/inspector_plugin/ui/modifier/components/parameter_bool.tscn
+++ b/src/stack/inspector_plugin/ui/modifier/components/parameter_bool.tscn
@@ -3,19 +3,16 @@
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier/components/parameter_bool.gd" id="1"]
 
 [node name="ParameterScalar" type="HBoxContainer"]
+anchors_preset = 10
 anchor_right = 1.0
-script = ExtResource( "1" )
+script = ExtResource("1")
 
 [node name="Label" type="Label" parent="."]
-offset_top = 2.0
-offset_right = 996.0
-offset_bottom = 28.0
+layout_mode = 2
 size_flags_horizontal = 3
 text = "Parameter name"
 
 [node name="CheckBox" type="CheckBox" parent="."]
-offset_left = 1000.0
-offset_right = 1024.0
-offset_bottom = 31.0
+layout_mode = 2
 focus_mode = 0
 mouse_filter = 1

--- a/src/stack/inspector_plugin/ui/modifier/components/parameter_curve.gd
+++ b/src/stack/inspector_plugin/ui/modifier/components/parameter_curve.gd
@@ -1,8 +1,8 @@
 @tool
-extends "base_parameter.gd"
+class_name ParameterCurve extends BaseParameter
 
 
-const Util = preload("../../../../../common/util.gd")
+#const Util = preload("../../../../../common/util.gd")
 
 
 @onready var _label: Label = $Label

--- a/src/stack/inspector_plugin/ui/modifier/components/parameter_curve.tscn
+++ b/src/stack/inspector_plugin/ui/modifier/components/parameter_curve.tscn
@@ -1,32 +1,24 @@
-[gd_scene load_steps=3 format=3]
+[gd_scene load_steps=3 format=3 uid="uid://dpvtwduvcaa5y"]
 
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier/components/parameter_curve.gd" id="1"]
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier/components/curve_panel.gd" id="2"]
 
 [node name="ParameterCurve" type="VBoxContainer"]
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource("1")
 
 [node name="Label" type="Label" parent="."]
-margin_right = 1280.0
-margin_bottom = 14.0
+layout_mode = 2
 text = "Curve name"
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
-margin_top = 18.0
-margin_right = 1280.0
-margin_bottom = 168.0
+layout_mode = 2
 
 [node name="CurvePanel" type="PanelContainer" parent="MarginContainer"]
-margin_right = 1280.0
-margin_bottom = 150.0
-rect_min_size = Vector2( 0, 150 )
-rect_clip_content = true
-script = ExtResource( 2 )
-selected_point_color = Color( 0.878431, 0.47451, 0, 1 )
+layout_mode = 2
+script = ExtResource("2")
+selected_point_color = Color(0.878431, 0.47451, 0, 1)
 
 [connection signal="curve_updated" from="MarginContainer/CurvePanel" to="." method="_on_curve_updated"]

--- a/src/stack/inspector_plugin/ui/modifier/components/parameter_file.gd
+++ b/src/stack/inspector_plugin/ui/modifier/components/parameter_file.gd
@@ -1,5 +1,5 @@
 @tool
-extends "base_parameter.gd"
+class_name ParameterFile extends BaseParameter
 
 
 @onready var _label: Label = $%Label

--- a/src/stack/inspector_plugin/ui/modifier/components/parameter_file.tscn
+++ b/src/stack/inspector_plugin/ui/modifier/components/parameter_file.tscn
@@ -14,74 +14,48 @@ script = ExtResource("2")
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
 layout_mode = 2
-offset_right = 1152.0
-offset_bottom = 31.0
 
 [node name="Label" type="Label" parent="HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_top = 2.0
-offset_right = 574.0
-offset_bottom = 28.0
 size_flags_horizontal = 3
 text = "Parameter name"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="HBoxContainer"]
 layout_mode = 2
-offset_left = 578.0
-offset_right = 1152.0
-offset_bottom = 31.0
 size_flags_horizontal = 3
 
 [node name="FileButton" type="Button" parent="HBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 546.0
-offset_bottom = 31.0
 size_flags_horizontal = 3
 text = "Select a file"
 
 [node name="ClearButton" type="Button" parent="HBoxContainer/HBoxContainer"]
 layout_mode = 2
-offset_left = 550.0
-offset_right = 574.0
-offset_bottom = 31.0
 icon = ExtResource("1")
 
 [node name="PreviewRoot" type="HBoxContainer" parent="."]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
-offset_top = 31.0
-offset_right = 1024.0
-offset_bottom = 39.0
 size_flags_horizontal = 3
 
 [node name="Control" type="Control" parent="PreviewRoot"]
 layout_mode = 2
-anchors_preset = 0
-offset_right = 1012.0
-offset_bottom = 8.0
 size_flags_horizontal = 3
 
 [node name="TextureButton" type="Button" parent="PreviewRoot"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 1016.0
-offset_right = 1024.0
-offset_bottom = 8.0
 flat = true
 
 [node name="Control" type="Control" parent="."]
 layout_mode = 2
-anchors_preset = 0
-offset_top = 31.0
-offset_right = 1152.0
-offset_bottom = 31.0
 
 [node name="FileDialog" type="FileDialog" parent="Control"]
 unique_name_in_owner = true
-title = "Open a texture file"
+title = "Open a File"
 size = Vector2i(400, 600)
 ok_button_text = "Open"
 file_mode = 0

--- a/src/stack/inspector_plugin/ui/modifier/components/parameter_node_selector.gd
+++ b/src/stack/inspector_plugin/ui/modifier/components/parameter_node_selector.gd
@@ -1,5 +1,5 @@
 @tool
-extends "base_parameter.gd"
+class_name ParameterNodeSelector extends BaseParameter
 
 
 @onready var _label: Label = $%Label

--- a/src/stack/inspector_plugin/ui/modifier/components/parameter_node_selector.tscn
+++ b/src/stack/inspector_plugin/ui/modifier/components/parameter_node_selector.tscn
@@ -10,24 +10,16 @@ script = ExtResource("2")
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
 layout_mode = 2
-offset_right = 1152.0
-offset_bottom = 31.0
 
 [node name="Label" type="Label" parent="HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_top = 2.0
-offset_right = 560.0
-offset_bottom = 28.0
 size_flags_horizontal = 3
 text = "Parameter name"
 
 [node name="SelectButton" type="Button" parent="HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 564.0
-offset_right = 1124.0
-offset_bottom = 31.0
 size_flags_horizontal = 3
 text = "Select Node"
 flat = true
@@ -35,9 +27,6 @@ flat = true
 [node name="ClearButton" type="Button" parent="HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 1128.0
-offset_right = 1152.0
-offset_bottom = 31.0
 icon = ExtResource("1")
 
 [node name="ConfirmationDialog" type="ConfirmationDialog" parent="."]
@@ -56,8 +45,6 @@ offset_bottom = -597.0
 [node name="Tree" type="Tree" parent="ConfirmationDialog/ScrollContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 184.0
-offset_bottom = 43.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 

--- a/src/stack/inspector_plugin/ui/modifier/components/parameter_scalar.gd
+++ b/src/stack/inspector_plugin/ui/modifier/components/parameter_scalar.gd
@@ -1,7 +1,7 @@
 # warning-ignore-all:return_value_discarded
 
 @tool
-extends "base_parameter.gd"
+class_name ParameterScalar extends BaseParameter
 
 
 var _is_int := false

--- a/src/stack/inspector_plugin/ui/modifier/components/parameter_scalar.tscn
+++ b/src/stack/inspector_plugin/ui/modifier/components/parameter_scalar.tscn
@@ -9,37 +9,25 @@ script = ExtResource("1")
 
 [node name="Label" type="Label" parent="."]
 layout_mode = 2
-offset_top = 2.0
-offset_right = 1833.0
-offset_bottom = 28.0
 size_flags_horizontal = 3
 text = "Parameter name"
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2
-offset_left = 1837.0
-offset_right = 1920.0
-offset_bottom = 31.0
 mouse_filter = 2
 
 [node name="Panel" type="Panel" parent="MarginContainer"]
 visible = false
 layout_mode = 2
-offset_right = 83.0
-offset_bottom = 31.0
 mouse_filter = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="MarginContainer"]
 layout_mode = 2
-offset_right = 83.0
-offset_bottom = 31.0
 mouse_filter = 2
 
 [node name="SpinBox" type="SpinBox" parent="MarginContainer/MarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 83.0
-offset_bottom = 31.0
 mouse_filter = 1
 min_value = -100.0
 step = 0.001
@@ -50,6 +38,4 @@ allow_lesser = true
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
-offset_right = 83.0
-offset_bottom = 31.0
 focus_mode = 0

--- a/src/stack/inspector_plugin/ui/modifier/components/parameter_string.gd
+++ b/src/stack/inspector_plugin/ui/modifier/components/parameter_string.gd
@@ -1,5 +1,5 @@
 @tool
-extends "base_parameter.gd"
+class_name ParameterString extends BaseParameter
 
 
 @onready var _label: Label = $Label

--- a/src/stack/inspector_plugin/ui/modifier/components/parameter_string.tscn
+++ b/src/stack/inspector_plugin/ui/modifier/components/parameter_string.tscn
@@ -1,56 +1,31 @@
-[gd_scene load_steps=4 format=3]
+[gd_scene load_steps=2 format=3 uid="uid://o75odiwi5lee"]
 
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier/components/parameter_string.gd" id="1"]
 
-[sub_resource type="StyleBoxFlat" id=1]
-bg_color = Color( 0, 0, 0, 0.392157 )
-
-[sub_resource type="StyleBoxFlat" id=2]
-bg_color = Color( 0.6, 0.6, 0.6, 0 )
-
 [node name="ParameterString" type="HBoxContainer"]
+anchors_preset = 10
 anchor_right = 1.0
-script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource("1")
 
 [node name="Label" type="Label" parent="."]
-margin_top = 2.0
-margin_right = 638.0
-margin_bottom = 16.0
+layout_mode = 2
 size_flags_horizontal = 3
 text = "Parameter name"
-valign = 1
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
-margin_left = 642.0
-margin_right = 1280.0
-margin_bottom = 18.0
-mouse_filter = 2
+layout_mode = 2
 size_flags_horizontal = 3
+mouse_filter = 2
 
 [node name="Panel" type="Panel" parent="MarginContainer"]
-margin_right = 638.0
-margin_bottom = 18.0
+layout_mode = 2
 mouse_filter = 2
-custom_styles/panel = SubResource( 1 )
 
 [node name="MarginContainer" type="MarginContainer" parent="MarginContainer"]
-margin_right = 638.0
-margin_bottom = 18.0
+layout_mode = 2
 mouse_filter = 2
-custom_constants/margin_right = 4
-custom_constants/margin_top = 2
-custom_constants/margin_left = 4
-custom_constants/margin_bottom = 2
 
 [node name="LineEdit" type="LineEdit" parent="MarginContainer/MarginContainer"]
-margin_left = 4.0
-margin_top = 2.0
-margin_right = 634.0
-margin_bottom = 16.0
+layout_mode = 2
 mouse_filter = 1
-custom_styles/focus = SubResource( 2 )
-custom_styles/normal = SubResource( 2 )
 clear_button_enabled = true

--- a/src/stack/inspector_plugin/ui/modifier/components/parameter_vector2.gd
+++ b/src/stack/inspector_plugin/ui/modifier/components/parameter_vector2.gd
@@ -1,7 +1,7 @@
 # warning-ignore-all:return_value_discarded
 
 @tool
-extends "base_parameter.gd"
+class_name ParameterVector2 extends BaseParameter
 
 
 @onready var _label: Label = $Label

--- a/src/stack/inspector_plugin/ui/modifier/components/parameter_vector2.tscn
+++ b/src/stack/inspector_plugin/ui/modifier/components/parameter_vector2.tscn
@@ -2,34 +2,30 @@
 
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier/components/parameter_vector2.gd" id="1"]
 [ext_resource type="Texture2D" uid="uid://bosx22dy64f11" path="res://addons/proton_scatter/icons/clear.svg" id="2"]
-[ext_resource type="Texture2D" uid="uid://dbn0ytoameq8f" path="res://addons/proton_scatter/icons/link.svg" id="3_u2lry"]
+[ext_resource type="Texture2D" uid="uid://86k7cvj3uc5u" path="res://addons/proton_scatter/icons/link.svg" id="3_u2lry"]
 
 [node name="ParameterVector2" type="HBoxContainer"]
+anchors_preset = 10
 anchor_right = 1.0
 script = ExtResource("1")
 
 [node name="Label" type="Label" parent="."]
-offset_right = 884.0
-offset_bottom = 66.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 5
 text = "Parameter name"
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
-offset_left = 888.0
-offset_right = 1024.0
-offset_bottom = 66.0
+layout_mode = 2
 size_flags_horizontal = 0
 mouse_filter = 2
 
 [node name="Panel" type="Panel" parent="MarginContainer"]
-offset_right = 136.0
-offset_bottom = 66.0
+layout_mode = 2
 mouse_filter = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="MarginContainer"]
-offset_right = 136.0
-offset_bottom = 66.0
+layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 4
 mouse_filter = 2
@@ -37,30 +33,22 @@ theme_override_constants/margin_left = 6
 theme_override_constants/margin_right = 6
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/MarginContainer"]
-offset_left = 6.0
-offset_right = 130.0
-offset_bottom = 66.0
+layout_mode = 2
 
 [node name="GridContainer" type="GridContainer" parent="MarginContainer/MarginContainer/HBoxContainer"]
-offset_right = 96.0
-offset_bottom = 66.0
+layout_mode = 2
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/MarginContainer/HBoxContainer/GridContainer"]
-offset_right = 96.0
-offset_bottom = 31.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="MarginContainer/MarginContainer/HBoxContainer/GridContainer/HBoxContainer"]
 modulate = Color(1, 0.447059, 0.368627, 1)
-offset_top = 2.0
-offset_right = 9.0
-offset_bottom = 28.0
+layout_mode = 2
 text = "x"
 
 [node name="X" type="SpinBox" parent="MarginContainer/MarginContainer/HBoxContainer/GridContainer/HBoxContainer"]
 unique_name_in_owner = true
-offset_left = 13.0
-offset_right = 96.0
-offset_bottom = 31.0
+layout_mode = 2
 mouse_filter = 1
 min_value = -100.0
 step = 0.001
@@ -68,22 +56,16 @@ allow_greater = true
 allow_lesser = true
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="MarginContainer/MarginContainer/HBoxContainer/GridContainer"]
-offset_top = 35.0
-offset_right = 96.0
-offset_bottom = 66.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="MarginContainer/MarginContainer/HBoxContainer/GridContainer/HBoxContainer2"]
 modulate = Color(0.564706, 0.992157, 0.298039, 1)
-offset_top = 2.0
-offset_right = 9.0
-offset_bottom = 28.0
+layout_mode = 2
 text = "y"
 
 [node name="Y" type="SpinBox" parent="MarginContainer/MarginContainer/HBoxContainer/GridContainer/HBoxContainer2"]
 unique_name_in_owner = true
-offset_left = 13.0
-offset_right = 96.0
-offset_bottom = 31.0
+layout_mode = 2
 mouse_filter = 1
 min_value = -100.0
 step = 0.001
@@ -91,18 +73,14 @@ allow_greater = true
 allow_lesser = true
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/MarginContainer/HBoxContainer"]
-offset_left = 100.0
-offset_right = 124.0
-offset_bottom = 66.0
+layout_mode = 2
 
 [node name="Control" type="Control" parent="MarginContainer/MarginContainer/HBoxContainer/VBoxContainer"]
-offset_right = 24.0
+layout_mode = 2
 size_flags_vertical = 3
 
 [node name="ClearButton" type="Button" parent="MarginContainer/MarginContainer/HBoxContainer/VBoxContainer"]
-offset_top = 4.0
-offset_right = 24.0
-offset_bottom = 28.0
+layout_mode = 2
 size_flags_vertical = 4
 focus_mode = 0
 mouse_filter = 1
@@ -110,16 +88,12 @@ icon = ExtResource("2")
 flat = true
 
 [node name="Control2" type="Control" parent="MarginContainer/MarginContainer/HBoxContainer/VBoxContainer"]
-offset_top = 32.0
-offset_right = 24.0
-offset_bottom = 33.0
+layout_mode = 2
 size_flags_vertical = 3
 
 [node name="LinkButton" type="Button" parent="MarginContainer/MarginContainer/HBoxContainer/VBoxContainer"]
 unique_name_in_owner = true
-offset_top = 37.0
-offset_right = 24.0
-offset_bottom = 61.0
+layout_mode = 2
 size_flags_vertical = 4
 focus_mode = 0
 mouse_filter = 1
@@ -128,9 +102,7 @@ icon = ExtResource("3_u2lry")
 flat = true
 
 [node name="Control3" type="Control" parent="MarginContainer/MarginContainer/HBoxContainer/VBoxContainer"]
-offset_top = 65.0
-offset_right = 24.0
-offset_bottom = 66.0
+layout_mode = 2
 size_flags_vertical = 3
 
 [connection signal="pressed" from="MarginContainer/MarginContainer/HBoxContainer/VBoxContainer/ClearButton" to="." method="_on_clear_pressed"]

--- a/src/stack/inspector_plugin/ui/modifier/components/parameter_vector3.gd
+++ b/src/stack/inspector_plugin/ui/modifier/components/parameter_vector3.gd
@@ -1,5 +1,5 @@
 @tool
-extends "base_parameter.gd"
+class_name ParameterVector3 extends BaseParameter
 
 
 @onready var _label: Label = $Label

--- a/src/stack/inspector_plugin/ui/modifier/components/parameter_vector3.tscn
+++ b/src/stack/inspector_plugin/ui/modifier/components/parameter_vector3.tscn
@@ -2,34 +2,30 @@
 
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier/components/parameter_vector3.gd" id="1"]
 [ext_resource type="Texture2D" uid="uid://bosx22dy64f11" path="res://addons/proton_scatter/icons/clear.svg" id="2"]
-[ext_resource type="Texture2D" uid="uid://dbn0ytoameq8f" path="res://addons/proton_scatter/icons/link.svg" id="3_gq2ti"]
+[ext_resource type="Texture2D" uid="uid://86k7cvj3uc5u" path="res://addons/proton_scatter/icons/link.svg" id="3_gq2ti"]
 
 [node name="ParameterVector3" type="HBoxContainer"]
+anchors_preset = 10
 anchor_right = 1.0
 script = ExtResource("1")
 
 [node name="Label" type="Label" parent="."]
-offset_right = 884.0
-offset_bottom = 101.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 5
 text = "Parameter name"
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
-offset_left = 888.0
-offset_right = 1024.0
-offset_bottom = 101.0
+layout_mode = 2
 size_flags_horizontal = 0
 mouse_filter = 2
 
 [node name="Panel" type="Panel" parent="MarginContainer"]
-offset_right = 136.0
-offset_bottom = 101.0
+layout_mode = 2
 mouse_filter = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="MarginContainer"]
-offset_right = 136.0
-offset_bottom = 101.0
+layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 4
 mouse_filter = 2
@@ -37,30 +33,22 @@ theme_override_constants/margin_left = 6
 theme_override_constants/margin_right = 6
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/MarginContainer"]
-offset_left = 6.0
-offset_right = 130.0
-offset_bottom = 101.0
+layout_mode = 2
 
 [node name="GridContainer" type="GridContainer" parent="MarginContainer/MarginContainer/HBoxContainer"]
-offset_right = 96.0
-offset_bottom = 101.0
+layout_mode = 2
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/MarginContainer/HBoxContainer/GridContainer"]
-offset_right = 96.0
-offset_bottom = 31.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="MarginContainer/MarginContainer/HBoxContainer/GridContainer/HBoxContainer"]
 modulate = Color(1, 0.447059, 0.368627, 1)
-offset_top = 2.0
-offset_right = 9.0
-offset_bottom = 28.0
+layout_mode = 2
 text = "x"
 
 [node name="X" type="SpinBox" parent="MarginContainer/MarginContainer/HBoxContainer/GridContainer/HBoxContainer"]
 unique_name_in_owner = true
-offset_left = 13.0
-offset_right = 96.0
-offset_bottom = 31.0
+layout_mode = 2
 mouse_filter = 1
 min_value = -100.0
 step = 0.001
@@ -68,22 +56,16 @@ allow_greater = true
 allow_lesser = true
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="MarginContainer/MarginContainer/HBoxContainer/GridContainer"]
-offset_top = 35.0
-offset_right = 96.0
-offset_bottom = 66.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="MarginContainer/MarginContainer/HBoxContainer/GridContainer/HBoxContainer2"]
 modulate = Color(0.564706, 0.992157, 0.298039, 1)
-offset_top = 2.0
-offset_right = 9.0
-offset_bottom = 28.0
+layout_mode = 2
 text = "y"
 
 [node name="Y" type="SpinBox" parent="MarginContainer/MarginContainer/HBoxContainer/GridContainer/HBoxContainer2"]
 unique_name_in_owner = true
-offset_left = 13.0
-offset_right = 96.0
-offset_bottom = 31.0
+layout_mode = 2
 mouse_filter = 1
 min_value = -100.0
 step = 0.001
@@ -91,22 +73,16 @@ allow_greater = true
 allow_lesser = true
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="MarginContainer/MarginContainer/HBoxContainer/GridContainer"]
-offset_top = 70.0
-offset_right = 96.0
-offset_bottom = 101.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="MarginContainer/MarginContainer/HBoxContainer/GridContainer/HBoxContainer3"]
 modulate = Color(0.14902, 0.8, 1, 1)
-offset_top = 2.0
-offset_right = 8.0
-offset_bottom = 28.0
+layout_mode = 2
 text = "z"
 
 [node name="Z" type="SpinBox" parent="MarginContainer/MarginContainer/HBoxContainer/GridContainer/HBoxContainer3"]
 unique_name_in_owner = true
-offset_left = 12.0
-offset_right = 95.0
-offset_bottom = 31.0
+layout_mode = 2
 mouse_filter = 1
 min_value = -100.0
 step = 0.001
@@ -114,21 +90,16 @@ allow_greater = true
 allow_lesser = true
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/MarginContainer/HBoxContainer"]
-offset_left = 100.0
-offset_right = 124.0
-offset_bottom = 101.0
+layout_mode = 2
 size_flags_vertical = 3
 alignment = 1
 
 [node name="Control3" type="Control" parent="MarginContainer/MarginContainer/HBoxContainer/VBoxContainer"]
-offset_right = 24.0
-offset_bottom = 12.0
+layout_mode = 2
 size_flags_vertical = 3
 
 [node name="ClearButton" type="Button" parent="MarginContainer/MarginContainer/HBoxContainer/VBoxContainer"]
-offset_top = 16.0
-offset_right = 24.0
-offset_bottom = 40.0
+layout_mode = 2
 size_flags_vertical = 4
 focus_mode = 0
 mouse_filter = 1
@@ -136,16 +107,12 @@ icon = ExtResource("2")
 flat = true
 
 [node name="Control" type="Control" parent="MarginContainer/MarginContainer/HBoxContainer/VBoxContainer"]
-offset_top = 44.0
-offset_right = 24.0
-offset_bottom = 56.0
+layout_mode = 2
 size_flags_vertical = 3
 
 [node name="LinkButton" type="Button" parent="MarginContainer/MarginContainer/HBoxContainer/VBoxContainer"]
 unique_name_in_owner = true
-offset_top = 60.0
-offset_right = 24.0
-offset_bottom = 84.0
+layout_mode = 2
 size_flags_vertical = 4
 focus_mode = 0
 mouse_filter = 1
@@ -154,9 +121,7 @@ icon = ExtResource("3_gq2ti")
 flat = true
 
 [node name="Control2" type="Control" parent="MarginContainer/MarginContainer/HBoxContainer/VBoxContainer"]
-offset_top = 88.0
-offset_right = 24.0
-offset_bottom = 101.0
+layout_mode = 2
 size_flags_vertical = 3
 
 [connection signal="pressed" from="MarginContainer/MarginContainer/HBoxContainer/VBoxContainer/ClearButton" to="." method="_on_clear_pressed"]

--- a/src/stack/inspector_plugin/ui/modifier/modifier_panel.gd
+++ b/src/stack/inspector_plugin/ui/modifier/modifier_panel.gd
@@ -1,5 +1,5 @@
 @tool
-extends Control
+class_name ModifierPanel extends Control
 
 
 signal value_changed
@@ -8,15 +8,15 @@ signal documentation_requested
 signal duplication_requested
 
 
-const ParameterBool := preload("./components/parameter_bool.tscn")
-const ParameterScalar := preload("./components/parameter_scalar.tscn")
-const ParameterNodeSelector = preload("./components/parameter_node_selector.tscn")
-const ParameterFile = preload("./components/parameter_file.tscn")
-const ParameterCurve = preload("./components/parameter_curve.tscn")
-const ParameterBitmask = preload("./components/parameter_bitmask.tscn")
-const ParameterString = preload("./components/parameter_string.tscn")
-const ParameterVector3 = preload("./components/parameter_vector3.tscn")
-const ParameterVector2 = preload("./components/parameter_vector2.tscn")
+const ParameterBoolNode := preload("./components/parameter_bool.tscn")
+const ParameterScalarNode := preload("./components/parameter_scalar.tscn")
+const ParameterNodeSelectorNode = preload("./components/parameter_node_selector.tscn")
+const ParameterFileNode = preload("./components/parameter_file.tscn")
+const ParameterCurveNode = preload("./components/parameter_curve.tscn")
+const ParameterBitmaskNode = preload("./components/parameter_bitmask.tscn")
+const ParameterStringNode = preload("./components/parameter_string.tscn")
+const ParameterVector3Node = preload("./components/parameter_vector3.tscn")
+const ParameterVector2Node = preload("./components/parameter_vector2.tscn")
 const PARAMETER_IGNORE_LIST := [
 	"enabled",
 	"override_global_seed",
@@ -110,28 +110,28 @@ func create_ui_for(modifier) -> void:
 		var parameter_ui
 		match property.type:
 			TYPE_BOOL:
-				parameter_ui = ParameterBool.instantiate()
+				parameter_ui = ParameterBoolNode.instantiate()
 			TYPE_FLOAT:
-				parameter_ui = ParameterScalar.instantiate()
+				parameter_ui = ParameterScalarNode.instantiate()
 			TYPE_INT:
 				if property.hint == PROPERTY_HINT_LAYERS_3D_PHYSICS:
-					parameter_ui = ParameterBitmask.instantiate()
+					parameter_ui = ParameterBitmaskNode.instantiate()
 				else:
-					parameter_ui = ParameterScalar.instantiate()
+					parameter_ui = ParameterScalarNode.instantiate()
 					parameter_ui.mark_as_int(true)
 			TYPE_STRING:
 				if property.hint_string == "File" or property.hint_string == "Texture":
-					parameter_ui = ParameterFile.instantiate()
+					parameter_ui = ParameterFileNode.instantiate()
 				elif property.hint_string == "Curve":
-					parameter_ui = ParameterCurve.instantiate()
+					parameter_ui = ParameterCurveNode.instantiate()
 				else:
-					parameter_ui = ParameterString.instantiate()
+					parameter_ui = ParameterStringNode.instantiate()
 			TYPE_VECTOR3:
-				parameter_ui = ParameterVector3.instantiate()
+				parameter_ui = ParameterVector3Node.instantiate()
 			TYPE_VECTOR2:
-				parameter_ui = ParameterVector2.instantiate()
+				parameter_ui = ParameterVector2Node.instantiate()
 			TYPE_NODE_PATH:
-				parameter_ui = ParameterNodeSelector.instantiate()
+				parameter_ui = ParameterNodeSelectorNode.instantiate()
 				parameter_ui.set_root(_scatter)
 
 		if parameter_ui:

--- a/src/stack/inspector_plugin/ui/modifier/modifier_panel.tscn
+++ b/src/stack/inspector_plugin/ui/modifier/modifier_panel.tscn
@@ -1,25 +1,14 @@
-[gd_scene load_steps=21 format=3 uid="uid://blpobpd0eweog"]
+[gd_scene load_steps=10 format=3 uid="uid://blpobpd0eweog"]
 
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier/modifier_panel.gd" id="1"]
-[ext_resource type="Texture2D" uid="uid://hshxh8s6k677" path="res://addons/proton_scatter/icons/arrow_right.svg" id="2_2djuo"]
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier/toggle_button.gd" id="4"]
-[ext_resource type="Texture2D" uid="uid://85r2q2fd8gyh" path="res://addons/proton_scatter/icons/arrow_down.svg" id="4_7nlfc"]
 [ext_resource type="Texture2D" uid="uid://dahwdjl2er75o" path="res://addons/proton_scatter/icons/close.svg" id="5"]
 [ext_resource type="Texture2D" uid="uid://n66mufjib4ds" path="res://addons/proton_scatter/icons/menu.svg" id="6_lmo8k"]
-[ext_resource type="Texture2D" uid="uid://dpigmdo0x73yb" path="res://addons/proton_scatter/icons/duplicate.svg" id="7_f6nan"]
-[ext_resource type="Texture2D" uid="uid://cnwg3p2m4lbf3" path="res://addons/proton_scatter/icons/doc.svg" id="7_owhij"]
 [ext_resource type="Texture2D" uid="uid://dj0y6peid681t" path="res://addons/proton_scatter/icons/warning.svg" id="9"]
-[ext_resource type="Texture2D" uid="uid://lkb3k4nuipjn" path="res://addons/proton_scatter/icons/drag_area.svg" id="9_t6pse"]
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier/override_seed_button.gd" id="10_ptukr"]
-[ext_resource type="Texture2D" uid="uid://dvlwsskebnfyf" path="res://addons/proton_scatter/icons/dice.svg" id="11_qwhro"]
 [ext_resource type="PackedScene" uid="uid://w6ycb4oveqhd" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier/components/header/parameter_button.tscn" id="11_y7srw"]
-[ext_resource type="Texture2D" uid="uid://bxgtlg3v183xe" path="res://addons/proton_scatter/icons/restrict_volume.svg" id="12_lx60d"]
-[ext_resource type="Texture2D" uid="uid://d4hayrcip1oo0" path="res://addons/proton_scatter/icons/local.svg" id="13_txjs8"]
 [ext_resource type="PackedScene" uid="uid://c36gqn03pvlnr" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier/components/header/parameter_spinbox.tscn" id="13_vhfch"]
-[ext_resource type="Texture2D" uid="uid://bjha4mlvffrca" path="res://addons/proton_scatter/icons/restrict_volume_lock.svg" id="15_0w0as"]
-[ext_resource type="Texture2D" uid="uid://bpygylbuxdu0f" path="res://addons/proton_scatter/icons/global.svg" id="16_ocvvf"]
 [ext_resource type="PackedScene" uid="uid://bspbhkrpgak0e" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier/components/parameter_scalar.tscn" id="17_aoulv"]
-[ext_resource type="Texture2D" uid="uid://be7s3se8bo32r" path="res://addons/proton_scatter/icons/individual_instances.svg" id="19_ln8a3"]
 
 [node name="ModifierPanel" type="MarginContainer"]
 anchors_preset = 10
@@ -30,15 +19,10 @@ script = ExtResource("1")
 
 [node name="Panel" type="Panel" parent="."]
 layout_mode = 2
-offset_right = 1920.0
-offset_bottom = 34.0
 mouse_filter = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2
-offset_right = 1920.0
-offset_bottom = 34.0
-grow_horizontal = 2
 mouse_filter = 2
 theme_override_constants/margin_left = 4
 theme_override_constants/margin_top = 4
@@ -49,39 +33,25 @@ metadata/_edit_use_custom_anchors = false
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
 layout_mode = 2
-offset_left = 4.0
-offset_top = 4.0
-offset_right = 1916.0
-offset_bottom = 30.0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
-offset_right = 1912.0
-offset_bottom = 26.0
 size_flags_vertical = 0
 
 [node name="Expand" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 20.0
-offset_bottom = 26.0
 tooltip_text = "Toggle the parameters view"
 focus_mode = 0
 mouse_filter = 1
 toggle_mode = true
-icon = ExtResource("2_2djuo")
 flat = true
 icon_alignment = 1
 script = ExtResource("4")
-default_icon = ExtResource("2_2djuo")
-pressed_icon = ExtResource("4_7nlfc")
 
 [node name="ModifierName" type="Label" parent="MarginContainer/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 24.0
-offset_right = 1808.0
-offset_bottom = 26.0
 size_flags_horizontal = 3
 text = "ModifierPanel"
 vertical_alignment = 1
@@ -89,9 +59,6 @@ clip_text = true
 
 [node name="Buttons" type="HBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
-offset_left = 1812.0
-offset_right = 1912.0
-offset_bottom = 26.0
 theme_override_constants/separation = 2
 alignment = 1
 
@@ -99,8 +66,6 @@ alignment = 1
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
-offset_right = 24.0
-offset_bottom = 31.0
 size_flags_horizontal = 0
 focus_mode = 0
 mouse_filter = 1
@@ -110,19 +75,15 @@ flat = true
 [node name="MenuButton" type="MenuButton" parent="MarginContainer/VBoxContainer/HBoxContainer/Buttons"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 24.0
-offset_bottom = 26.0
 tooltip_text = "Show options"
 icon = ExtResource("6_lmo8k")
 item_count = 4
 popup/item_0/text = "Show documentation"
-popup/item_0/icon = ExtResource("7_owhij")
 popup/item_0/id = 0
 popup/item_1/text = ""
 popup/item_1/id = 1
 popup/item_1/separator = true
 popup/item_2/text = "Duplicate"
-popup/item_2/icon = ExtResource("7_f6nan")
 popup/item_2/id = 2
 popup/item_3/text = "Delete"
 popup/item_3/icon = ExtResource("5")
@@ -131,9 +92,6 @@ popup/item_3/id = 3
 [node name="Enabled" type="CheckBox" parent="MarginContainer/VBoxContainer/HBoxContainer/Buttons"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 26.0
-offset_right = 50.0
-offset_bottom = 26.0
 tooltip_text = "Toggle the modifier.
 
 If the modifier is disabled, it will not contribute to the final result but will still remain in the stack.
@@ -145,10 +103,6 @@ mouse_filter = 1
 [node name="Remove" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/Buttons"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 52.0
-offset_top = 1.0
-offset_right = 76.0
-offset_bottom = 25.0
 size_flags_vertical = 4
 tooltip_text = "Delete the modifier.
 This will remove it from the stack."
@@ -161,30 +115,20 @@ icon_alignment = 1
 [node name="VSeparator" type="VSeparator" parent="MarginContainer/VBoxContainer/HBoxContainer/Buttons"]
 modulate = Color(1, 1, 1, 0.54902)
 layout_mode = 2
-offset_left = 78.0
-offset_right = 82.0
-offset_bottom = 26.0
 
 [node name="DragControl" type="TextureRect" parent="MarginContainer/VBoxContainer/HBoxContainer/Buttons"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 84.0
-offset_right = 100.0
-offset_bottom = 26.0
 tooltip_text = "Drag and move this button to change the stack order. 
 
 Modifiers are processed from top to bottom."
 mouse_default_cursor_shape = 6
-texture = ExtResource("9_t6pse")
 stretch_mode = 3
 
 [node name="ParametersContainer" type="MarginContainer" parent="MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
-offset_top = 30.0
-offset_right = 1912.0
-offset_bottom = 72.0
 theme_override_constants/margin_left = 3
 theme_override_constants/margin_top = 3
 theme_override_constants/margin_right = 3
@@ -192,154 +136,87 @@ theme_override_constants/margin_bottom = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ParametersContainer"]
 layout_mode = 2
-offset_left = 3.0
-offset_top = 3.0
-offset_right = 1909.0
-offset_bottom = 39.0
 
 [node name="ParametersRoot" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ParametersContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 1906.0
 
 [node name="HSeparator" type="HSeparator" parent="MarginContainer/VBoxContainer/ParametersContainer/VBoxContainer"]
 layout_mode = 2
-offset_top = 4.0
-offset_right = 1906.0
-offset_bottom = 8.0
 
 [node name="CommonHeader" type="HBoxContainer" parent="MarginContainer/VBoxContainer/ParametersContainer/VBoxContainer"]
 layout_mode = 2
-offset_top = 12.0
-offset_right = 1906.0
-offset_bottom = 36.0
 size_flags_vertical = 4
 alignment = 1
 
 [node name="ExpandButton" type="MarginContainer" parent="MarginContainer/VBoxContainer/ParametersContainer/VBoxContainer/CommonHeader"]
 layout_mode = 2
-offset_right = 24.0
-offset_bottom = 24.0
 script = ExtResource("10_ptukr")
 
 [node name="OverrideGlobalSeed" parent="MarginContainer/VBoxContainer/ParametersContainer/VBoxContainer/CommonHeader/ExpandButton" instance=ExtResource("11_y7srw")]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 24.0
-offset_bottom = 24.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Button" parent="MarginContainer/VBoxContainer/ParametersContainer/VBoxContainer/CommonHeader/ExpandButton/OverrideGlobalSeed" index="0"]
 layout_mode = 2
-offset_right = 24.0
-offset_bottom = 24.0
 tooltip_text = "Random seed.
 
 Enable to force a custom seed on this modifier only. If this option is disabled, the Global Seed from the ProtonScatter node will be used instead."
-icon = ExtResource("11_qwhro")
 icon_alignment = 0
-default_icon = ExtResource("11_qwhro")
-pressed_icon = ExtResource("11_qwhro")
 
 [node name="SpinBoxRoot" type="HBoxContainer" parent="MarginContainer/VBoxContainer/ParametersContainer/VBoxContainer/CommonHeader/ExpandButton"]
 visible = false
 layout_mode = 2
-offset_right = 24.0
-offset_bottom = 24.0
 mouse_filter = 2
 
 [node name="VSeparator" type="VSeparator" parent="MarginContainer/VBoxContainer/ParametersContainer/VBoxContainer/CommonHeader/ExpandButton/SpinBoxRoot"]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
-offset_right = 28.0
-offset_bottom = 31.0
 mouse_filter = 2
 theme_override_constants/separation = 28
 
 [node name="CustomSeed" parent="MarginContainer/VBoxContainer/ParametersContainer/VBoxContainer/CommonHeader/ExpandButton/SpinBoxRoot" instance=ExtResource("13_vhfch")]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 31.0
-offset_right = 114.062
 
 [node name="Control" type="Control" parent="MarginContainer/VBoxContainer/ParametersContainer/VBoxContainer/CommonHeader"]
 layout_mode = 2
-anchors_preset = 0
-offset_left = 28.0
-offset_right = 1831.0
-offset_bottom = 24.0
 size_flags_horizontal = 3
 
 [node name="RestrictHeight" parent="MarginContainer/VBoxContainer/ParametersContainer/VBoxContainer/CommonHeader" instance=ExtResource("11_y7srw")]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 1835.0
-offset_right = 1859.0
-offset_bottom = 24.0
 size_flags_horizontal = 1
 size_flags_vertical = 3
 
 [node name="Button" parent="MarginContainer/VBoxContainer/ParametersContainer/VBoxContainer/CommonHeader/RestrictHeight" index="0"]
 layout_mode = 2
-offset_right = 24.0
-offset_bottom = 24.0
 tooltip_text = "Restrict height.
 
 If enabled, the modifier will try to remain in the local XZ plane instead of using the full volume defined by the ScatterShapes."
-icon = ExtResource("12_lx60d")
-default_icon = ExtResource("12_lx60d")
-pressed_icon = ExtResource("15_0w0as")
 
 [node name="TransformSpace" parent="MarginContainer/VBoxContainer/ParametersContainer/VBoxContainer/CommonHeader" instance=ExtResource("17_aoulv")]
 unique_name_in_owner = true
 layout_mode = 2
-anchors_preset = 0
-anchor_right = 0.0
-offset_left = 1863.0
-offset_right = 1906.0
-offset_bottom = 24.0
-grow_horizontal = 2
 
 [node name="Label" parent="MarginContainer/VBoxContainer/ParametersContainer/VBoxContainer/CommonHeader/TransformSpace" index="0"]
 visible = false
-offset_top = 4.0
-offset_right = 1.0
-offset_bottom = 27.0
 text = ""
-
-[node name="MarginContainer" parent="MarginContainer/VBoxContainer/ParametersContainer/VBoxContainer/CommonHeader/TransformSpace" index="1"]
-offset_left = 0.0
-offset_right = 43.0
-offset_bottom = 24.0
-
-[node name="Panel" parent="MarginContainer/VBoxContainer/ParametersContainer/VBoxContainer/CommonHeader/TransformSpace/MarginContainer" index="0"]
-offset_right = 43.0
-offset_bottom = 24.0
-
-[node name="MarginContainer" parent="MarginContainer/VBoxContainer/ParametersContainer/VBoxContainer/CommonHeader/TransformSpace/MarginContainer" index="1"]
-offset_right = 43.0
-offset_bottom = 24.0
 
 [node name="SpinBox" parent="MarginContainer/VBoxContainer/ParametersContainer/VBoxContainer/CommonHeader/TransformSpace/MarginContainer/MarginContainer" index="0"]
 visible = false
-offset_right = 43.0
-offset_bottom = 24.0
 
 [node name="OptionButton" parent="MarginContainer/VBoxContainer/ParametersContainer/VBoxContainer/CommonHeader/TransformSpace/MarginContainer/MarginContainer" index="1"]
 visible = true
-offset_right = 43.0
-offset_bottom = 24.0
 item_count = 3
 fit_to_longest_item = false
 popup/item_0/text = "Global"
-popup/item_0/icon = ExtResource("16_ocvvf")
 popup/item_0/id = 0
 popup/item_1/text = "Local"
-popup/item_1/icon = ExtResource("13_txjs8")
 popup/item_1/id = 1
 popup/item_2/text = "Individual"
-popup/item_2/icon = ExtResource("19_ln8a3")
 popup/item_2/id = 2
 
 [node name="WarningDialog" type="AcceptDialog" parent="."]

--- a/src/stack/inspector_plugin/ui/modifier/modifier_panel.tscn
+++ b/src/stack/inspector_plugin/ui/modifier/modifier_panel.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=10 format=3 uid="uid://blpobpd0eweog"]
+[gd_scene load_steps=13 format=3 uid="uid://blpobpd0eweog"]
 
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier/modifier_panel.gd" id="1"]
+[ext_resource type="Texture2D" uid="uid://cx07j7houcyks" path="res://addons/proton_scatter/icons/arrow_right.svg" id="2_lhumm"]
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier/toggle_button.gd" id="4"]
+[ext_resource type="Texture2D" uid="uid://deqfr62cnnatf" path="res://addons/proton_scatter/icons/arrow_down.svg" id="4_j1frm"]
 [ext_resource type="Texture2D" uid="uid://dahwdjl2er75o" path="res://addons/proton_scatter/icons/close.svg" id="5"]
 [ext_resource type="Texture2D" uid="uid://n66mufjib4ds" path="res://addons/proton_scatter/icons/menu.svg" id="6_lmo8k"]
+[ext_resource type="Texture2D" uid="uid://cib4ay0u4lduh" path="res://addons/proton_scatter/icons/drag_area.svg" id="8_4c07b"]
 [ext_resource type="Texture2D" uid="uid://dj0y6peid681t" path="res://addons/proton_scatter/icons/warning.svg" id="9"]
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier/override_seed_button.gd" id="10_ptukr"]
 [ext_resource type="PackedScene" uid="uid://w6ycb4oveqhd" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier/components/header/parameter_button.tscn" id="11_y7srw"]
@@ -40,14 +43,18 @@ size_flags_vertical = 0
 
 [node name="Expand" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
+custom_minimum_size = Vector2(30, 0)
 layout_mode = 2
 tooltip_text = "Toggle the parameters view"
 focus_mode = 0
 mouse_filter = 1
 toggle_mode = true
+icon = ExtResource("2_lhumm")
 flat = true
 icon_alignment = 1
 script = ExtResource("4")
+default_icon = ExtResource("2_lhumm")
+pressed_icon = ExtResource("4_j1frm")
 
 [node name="ModifierName" type="Label" parent="MarginContainer/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
@@ -59,8 +66,9 @@ clip_text = true
 
 [node name="Buttons" type="HBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
+size_flags_horizontal = 8
 theme_override_constants/separation = 2
-alignment = 1
+alignment = 2
 
 [node name="Warning" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/Buttons"]
 unique_name_in_owner = true
@@ -118,11 +126,14 @@ layout_mode = 2
 
 [node name="DragControl" type="TextureRect" parent="MarginContainer/VBoxContainer/HBoxContainer/Buttons"]
 unique_name_in_owner = true
+custom_minimum_size = Vector2(30, 0)
 layout_mode = 2
+size_flags_horizontal = 10
 tooltip_text = "Drag and move this button to change the stack order. 
 
 Modifiers are processed from top to bottom."
 mouse_default_cursor_shape = 6
+texture = ExtResource("8_4c07b")
 stretch_mode = 3
 
 [node name="ParametersContainer" type="MarginContainer" parent="MarginContainer/VBoxContainer"]

--- a/src/stack/inspector_plugin/ui/stack_panel.gd
+++ b/src/stack/inspector_plugin/ui/stack_panel.gd
@@ -2,14 +2,14 @@
 extends Control
 
 
-const ModifierPanel := preload("./modifier/modifier_panel.tscn")
+const ModifierPanelNode := preload("./modifier/modifier_panel.tscn")
 
 
 @onready var _modifiers_container: Control = $%ModifiersContainer
 @onready var _modifiers_popup: PopupPanel = $%ModifiersPopup
 
 var _scatter
-var _modifier_stack
+var _modifier_stack :ModifierStack
 var _undo_redo
 var _is_ready := false
 
@@ -44,7 +44,7 @@ func rebuild_ui() -> void:
 	_validate_stack_connections()
 	_clear()
 	for m in _modifier_stack.stack:
-		var ui = ModifierPanel.instantiate()
+		var ui = ModifierPanelNode.instantiate()
 		_modifiers_container.add_child(ui)
 		ui.set_root(_scatter)
 		ui.create_ui_for(m)

--- a/src/stack/inspector_plugin/ui/stack_panel.tscn
+++ b/src/stack/inspector_plugin/ui/stack_panel.tscn
@@ -3,12 +3,12 @@
 [ext_resource type="Texture2D" uid="uid://cun73k8jdmr4e" path="res://addons/proton_scatter/icons/add.svg" id="1_4vwtj"]
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/stack_panel.gd" id="1_ga4or"]
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier/drag_container.gd" id="1_hg5ys"]
-[ext_resource type="Texture2D" uid="uid://bl3ngfq3rv5i" path="res://addons/proton_scatter/icons/rebuild.svg" id="2_svid4"]
+[ext_resource type="Texture2D" uid="uid://d2q0ecpon840i" path="res://addons/proton_scatter/icons/rebuild.svg" id="2_svid4"]
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/add_modifier_button.gd" id="3_01ldn"]
 [ext_resource type="PackedScene" uid="uid://belutr5odecw2" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier_list_popup/popup.tscn" id="3_pkswu"]
 [ext_resource type="Texture2D" uid="uid://ddjrq1h4mkn6a" path="res://addons/proton_scatter/icons/load.svg" id="3_w72lv"]
 [ext_resource type="Texture2D" uid="uid://b2omj2e03x72e" path="res://addons/proton_scatter/icons/save.svg" id="4_5l2cx"]
-[ext_resource type="Texture2D" uid="uid://bg22siy20wrwp" path="res://addons/proton_scatter/icons/doc.svg" id="8_fgqhd"]
+[ext_resource type="Texture2D" uid="uid://cnwg3p2m4lbf3" path="res://addons/proton_scatter/icons/doc.svg" id="8_fgqhd"]
 [ext_resource type="PackedScene" uid="uid://cfg8iqtuion8b" path="res://addons/proton_scatter/src/documentation/documentation.tscn" id="9_y57kc"]
 [ext_resource type="PackedScene" uid="uid://bcsosdvstytoq" path="res://addons/proton_scatter/src/presets/presets.tscn" id="11_2ut8s"]
 
@@ -25,13 +25,21 @@ script = ExtResource("1_ga4or")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
+offset_left = 4.0
+offset_top = 4.0
+offset_right = 452.0
+offset_bottom = 140.0
 theme_override_constants/separation = 16
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
+offset_right = 448.0
+offset_bottom = 31.0
 
 [node name="Add" type="Button" parent="VBoxContainer/HBoxContainer"]
 layout_mode = 2
+offset_right = 131.0
+offset_bottom = 31.0
 size_flags_horizontal = 2
 focus_mode = 0
 toggle_mode = true
@@ -47,6 +55,9 @@ visible = false
 [node name="Rebuild" type="Button" parent="VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+offset_left = 324.0
+offset_right = 348.0
+offset_bottom = 31.0
 size_flags_horizontal = 4
 tooltip_text = "Force rebuild.
 
@@ -60,10 +71,16 @@ icon_alignment = 1
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/HBoxContainer"]
 modulate = Color(1, 1, 1, 0.54902)
 layout_mode = 2
+offset_left = 352.0
+offset_right = 356.0
+offset_bottom = 31.0
 
 [node name="LoadPreset" type="Button" parent="VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+offset_left = 360.0
+offset_right = 384.0
+offset_bottom = 31.0
 tooltip_text = "Load a preset."
 focus_mode = 0
 text = "
@@ -74,6 +91,9 @@ icon_alignment = 1
 [node name="SavePreset" type="Button" parent="VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+offset_left = 388.0
+offset_right = 412.0
+offset_bottom = 31.0
 tooltip_text = "Save a preset."
 focus_mode = 0
 text = "
@@ -84,10 +104,16 @@ icon_alignment = 1
 [node name="VSeparator2" type="VSeparator" parent="VBoxContainer/HBoxContainer"]
 modulate = Color(1, 1, 1, 0.54902)
 layout_mode = 2
+offset_left = 416.0
+offset_right = 420.0
+offset_bottom = 31.0
 
 [node name="DocumentationButton" type="Button" parent="VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+offset_left = 424.0
+offset_right = 448.0
+offset_bottom = 31.0
 tooltip_text = "Open documentation"
 focus_mode = 0
 text = "
@@ -100,6 +126,9 @@ unique_name_in_owner = true
 clip_children = 1
 custom_minimum_size = Vector2(0, -4)
 layout_mode = 2
+offset_top = 47.0
+offset_right = 448.0
+offset_bottom = 136.0
 size_flags_vertical = 3
 mouse_filter = 0
 script = ExtResource("1_hg5ys")

--- a/src/stack/inspector_plugin/ui/stack_panel.tscn
+++ b/src/stack/inspector_plugin/ui/stack_panel.tscn
@@ -3,12 +3,12 @@
 [ext_resource type="Texture2D" uid="uid://cun73k8jdmr4e" path="res://addons/proton_scatter/icons/add.svg" id="1_4vwtj"]
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/stack_panel.gd" id="1_ga4or"]
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier/drag_container.gd" id="1_hg5ys"]
-[ext_resource type="Texture2D" uid="uid://d2q0ecpon840i" path="res://addons/proton_scatter/icons/rebuild.svg" id="2_svid4"]
+[ext_resource type="Texture2D" uid="uid://bl3ngfq3rv5i" path="res://addons/proton_scatter/icons/rebuild.svg" id="2_svid4"]
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/add_modifier_button.gd" id="3_01ldn"]
 [ext_resource type="PackedScene" uid="uid://belutr5odecw2" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/modifier_list_popup/popup.tscn" id="3_pkswu"]
 [ext_resource type="Texture2D" uid="uid://ddjrq1h4mkn6a" path="res://addons/proton_scatter/icons/load.svg" id="3_w72lv"]
 [ext_resource type="Texture2D" uid="uid://b2omj2e03x72e" path="res://addons/proton_scatter/icons/save.svg" id="4_5l2cx"]
-[ext_resource type="Texture2D" uid="uid://cnwg3p2m4lbf3" path="res://addons/proton_scatter/icons/doc.svg" id="8_fgqhd"]
+[ext_resource type="Texture2D" uid="uid://bg22siy20wrwp" path="res://addons/proton_scatter/icons/doc.svg" id="8_fgqhd"]
 [ext_resource type="PackedScene" uid="uid://cfg8iqtuion8b" path="res://addons/proton_scatter/src/documentation/documentation.tscn" id="9_y57kc"]
 [ext_resource type="PackedScene" uid="uid://bcsosdvstytoq" path="res://addons/proton_scatter/src/presets/presets.tscn" id="11_2ut8s"]
 
@@ -25,21 +25,13 @@ script = ExtResource("1_ga4or")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
-offset_left = 4.0
-offset_top = 4.0
-offset_right = 452.0
-offset_bottom = 140.0
 theme_override_constants/separation = 16
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
-offset_right = 448.0
-offset_bottom = 31.0
 
 [node name="Add" type="Button" parent="VBoxContainer/HBoxContainer"]
 layout_mode = 2
-offset_right = 131.0
-offset_bottom = 31.0
 size_flags_horizontal = 2
 focus_mode = 0
 toggle_mode = true
@@ -55,9 +47,6 @@ visible = false
 [node name="Rebuild" type="Button" parent="VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 324.0
-offset_right = 348.0
-offset_bottom = 31.0
 size_flags_horizontal = 4
 tooltip_text = "Force rebuild.
 
@@ -71,16 +60,10 @@ icon_alignment = 1
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/HBoxContainer"]
 modulate = Color(1, 1, 1, 0.54902)
 layout_mode = 2
-offset_left = 352.0
-offset_right = 356.0
-offset_bottom = 31.0
 
 [node name="LoadPreset" type="Button" parent="VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 360.0
-offset_right = 384.0
-offset_bottom = 31.0
 tooltip_text = "Load a preset."
 focus_mode = 0
 text = "
@@ -91,9 +74,6 @@ icon_alignment = 1
 [node name="SavePreset" type="Button" parent="VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 388.0
-offset_right = 412.0
-offset_bottom = 31.0
 tooltip_text = "Save a preset."
 focus_mode = 0
 text = "
@@ -104,16 +84,10 @@ icon_alignment = 1
 [node name="VSeparator2" type="VSeparator" parent="VBoxContainer/HBoxContainer"]
 modulate = Color(1, 1, 1, 0.54902)
 layout_mode = 2
-offset_left = 416.0
-offset_right = 420.0
-offset_bottom = 31.0
 
 [node name="DocumentationButton" type="Button" parent="VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 424.0
-offset_right = 448.0
-offset_bottom = 31.0
 tooltip_text = "Open documentation"
 focus_mode = 0
 text = "
@@ -126,9 +100,6 @@ unique_name_in_owner = true
 clip_children = 1
 custom_minimum_size = Vector2(0, -4)
 layout_mode = 2
-offset_top = 47.0
-offset_right = 448.0
-offset_bottom = 136.0
 size_flags_vertical = 3
 mouse_filter = 0
 script = ExtResource("1_hg5ys")

--- a/src/stack/modifier_stack.gd
+++ b/src/stack/modifier_stack.gd
@@ -1,12 +1,12 @@
 @tool
-extends Resource
+class_name ModifierStack extends Resource
 
 
 signal stack_changed
 signal value_changed
 
 
-const TransformList = preload("res://addons/proton_scatter/src/common/transform_list.gd")
+#const TransformList = preload("res://addons/proton_scatter/src/common/transform_list.gd")
 
 
 @export var stack: Array[Resource] = []
@@ -14,7 +14,7 @@ const TransformList = preload("res://addons/proton_scatter/src/common/transform_
 var just_created := false
 
 
-func update(scatter_node: Node3D, domain) -> TransformList:
+func update(scatter_node: Node3D, domain:Domain) -> TransformList:
 	var transforms = TransformList.new()
 	for modifier in stack:
 		modifier.process_transforms(transforms, domain, scatter_node.global_seed)


### PR DESCRIPTION
### **THIS IS A DRAFT, REQUIRE FURTHER WORK**
![image](https://user-images.githubusercontent.com/16803994/213369412-fce04012-7ff9-4cf7-be64-07d4cef01187.png)


Result : 
- Only tested in Godot v4 beta 13, but could work in previous betas.
- No more errors or important warning in the demo scene. The only warnings are due to UID import being different so they use the text path instead.
- All class are now static type with proper name. 
- Projection on collider now works as intended

This is a lot of changes and is still a WIP but here are the main topics : 

0. **States of v4**
 I've been vocal that this addon was in a weird but functional state. The errors and warning while using this addon were adding up very quickly. Project on collider wasn't working, but for some reason it was possible to make it work by dragging ScatterShape around the scene using the Gizmo, but not always and it was sure to generate a lot of errors and message.
 My main goal was to fix the projection issues, and fixes those errors messages.

1. **Physics Query** aka the big change
The main problem I wanted to tackle. Since Beta 6 ( I think), direct_space_state are only accessible in the physics process. This wasn't working with the Domain.root setter that also set the space_state whenever it requires a copy. The solution is to replace Domain.space_state with the RID space_state_rid, and in the modifier requiring physics, await the physics_process and store the  space_state 
    ``` Python
    await domain.root.get_tree().physics_frame
    var space_state = PhysicsServer3d.space_get_direct_state(domain.space_state_rid)
    ```
    Another approach that I tried was to modify the modifier_stack.update function to run on physics, but I wasn't able to make it          work in another Thread.
    Look at 'src/common/domain.gd' and 'src/modifiers/project_on_geometry.gd' for more info.

2. **Static Typing and UI refactoring**
There was too much debug message in the editor and while running.  The code had a lot of remnant of Godot3 where you declare Class and Node using the same preload function. It was working-ish but mistaking one for the other would cause some problem. Godot 4 fixed cyclic dependencies so I tried to migrate to this and use proper name for class. I think I found one `new()` that was suppose to be a `instanciate()`. Here the gist of what I've changed  : 

    ``` Python
    # Scene reference are now suffixed with Node to know that it's a Scene 
    # ( I might suffix them with Scene when I think about it)
    # const ParameterBool := preload("./components/parameter_bool.tscn")
    const ParameterBoolNode := preload("./components/parameter_bool.tscn")

    # Define properly the class_name
    class_name Scatter extends Node3D
    # Comment each reference to the script preloaded with the proper name
    # I've kept them as comment for the review but it isn't required anymore
    # const Scatter = preload("../scatter.gd")
    ```

3. **There is still work to do !**
There is this error when dragging ScatterShapes around the scene : 
```
  ./core/templates/self_list.h:80 - Condition "p_elem->_root != this" is true.
  scene/3d/node_3d.cpp:308 - Condition "!is_inside_tree()" is true. Returning: Transform3D()
  Error calling forwarded method from 'get_drag_data': 'Node3DEditorViewport::_get_drag_data_fw': Method not found.
```
I may have modified UI scene but it wasn't my intention. The documentation didn't seems to change, neither does the modifier panel, but I didn't test proxys and presets manipulation.

I believe this is as far as I can push the move to godot v4 without breaking something unintentionally.








