### PR TITLE
Add blocking layer for projection

### DIFF
--- a/addons/proton_scatter/src/modifiers/project_on_geometry.gd
+++ b/addons/proton_scatter/src/modifiers/project_on_geometry.gd
@@ -151,7 +151,9 @@ func _process_transforms(transforms, domain, _seed) -> void:
 		exclude_queries[index].to = hit.position # only cast up to hit point for correct ordering
 		index += 1
 	
-	var exclude_hits := await physics_helper.execute(exclude_queries)
+	var exclude_hits : Array[Dictionary] = []
+	if exclude_mask != 0: # Only cast the rays if it makes any sense
+		exclude_hits = await physics_helper.execute(exclude_queries)
 	
 	# Apply the results
 	index = 0
@@ -170,9 +172,10 @@ func _process_transforms(transforms, domain, _seed) -> void:
 			is_point_valid = d >= (1.0 - remapped_max_slope)
 
 		# use pop because index is not always incremented
-		var exclude_hit = exclude_hits.pop_front() 
-		if not exclude_hit.is_empty():
-			is_point_valid = false
+		var exclude_hit = exclude_hits.pop_front()
+		if exclude_hit != null:
+			if not exclude_hit.is_empty():
+				is_point_valid = false
 
 		if is_point_valid:
 			t = transforms.list[index]

--- a/addons/proton_scatter/src/modifiers/project_on_geometry.gd
+++ b/addons/proton_scatter/src/modifiers/project_on_geometry.gd
@@ -142,14 +142,14 @@ func _process_transforms(transforms, domain, _seed) -> void:
 		return
 
 	# Create queries from the hit points
-	var index := 0
+	var index := -1
 	for ray_hit in ray_hits:
+		index += 1
 		var hit : Dictionary = ray_hit
 		if hit.is_empty():
 			exclude_queries[index].collision_mask = 0 # this point is empty anyway, we dont care
 			continue
 		exclude_queries[index].to = hit.position # only cast up to hit point for correct ordering
-		index += 1
 	
 	var exclude_hits : Array[Dictionary] = []
 	if exclude_mask != 0: # Only cast the rays if it makes any sense
@@ -161,6 +161,7 @@ func _process_transforms(transforms, domain, _seed) -> void:
 	var t: Transform3D
 	var remapped_max_slope = remap(max_slope, 0.0, 90.0, 0.0, 1.0)
 	var is_point_valid := false
+	exclude_hits.reverse()
 
 	for hit in ray_hits:
 		is_point_valid = true
@@ -172,7 +173,7 @@ func _process_transforms(transforms, domain, _seed) -> void:
 			is_point_valid = d >= (1.0 - remapped_max_slope)
 
 		# use pop because index is not always incremented
-		var exclude_hit = exclude_hits.pop_front()
+		var exclude_hit = exclude_hits.pop_back() 
 		if exclude_hit != null:
 			if not exclude_hit.is_empty():
 				is_point_valid = false


### PR DESCRIPTION
I added an extra collision mask to the project on geometry modifier.
This mask can be used to create blocking layers.

The idea came when we wanted to block grass from growing on boulders. I think this can be useful in other cases so I added it to the plugin instead of adding a negative shape to all boulders.

This change is totally backwards compatible because when using 0 as the mask the behaviour is exactly the same as before the change.