### PR TITLE
Few improvements to handle more error cases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,33 @@
+name: Status Checks
+
+on:
+  push:
+    branches: [ v4 ]
+  pull_request:
+    branches: [ v4 ]
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: Evaluate on ${{ matrix.os }} with Godot ${{ matrix.godot_version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        godot_version: [ '4.0.3', '4.1.0' ]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Godot
+        uses: chickensoft-games/setup-godot@v1
+        with:
+          version: ${{ matrix.godot_version }}
+          use-dotnet: false
+
+      - name: Import files
+        run: godot --editor --headless --quit --quiet

--- a/addons/proton_scatter/src/modifiers/relax.gd
+++ b/addons/proton_scatter/src/modifiers/relax.gd
@@ -36,15 +36,14 @@ func _process_transforms(transforms, _domain, _seed) -> void:
 		return
 	
 	# Disable the use of compute shader, if we cannot create a RenderingDevice
-	var rd = null
 	if use_computeshader:
-		rd = RenderingServer.create_local_rendering_device()
+		var rd := RenderingServer.create_local_rendering_device()
 		if rd == null:
 			use_computeshader = false
 
 	if use_computeshader:
 		for iteration in iterations:
-			var movedir : PackedVector3Array = compute_closest(transforms, rd)
+			var movedir: PackedVector3Array = compute_closest(transforms)
 			for i in transforms.size():
 				var dir = movedir[i]
 				if restrict_height:
@@ -86,11 +85,10 @@ func _process_transforms(transforms, _domain, _seed) -> void:
 
 # compute the closest points to each other using a compute shader
 # return a vector for each point that points away from the closest neighbour
-func compute_closest(transforms, rd: RenderingDevice = null) -> PackedVector3Array:
+func compute_closest(transforms) -> PackedVector3Array:
 	var padded_num_vecs = ceil(float(transforms.size()) / 64.0) * 64
 	var padded_num_floats = padded_num_vecs * 4
-	if rd == null:
-		rd := RenderingServer.create_local_rendering_device()
+	var rd := RenderingServer.create_local_rendering_device()
 	var shader_spirv: RDShaderSPIRV = shader_file.get_spirv()
 	var shader := rd.shader_create_from_spirv(shader_spirv)
 	# Prepare our data. We use vec4 floats in the shader, so we need 32 bit.

--- a/addons/proton_scatter/src/scatter.gd
+++ b/addons/proton_scatter/src/scatter.gd
@@ -128,6 +128,9 @@ func _ready() -> void:
 func _exit_tree():
 	_clear_collision_data()
 
+	if is_thread_running():
+		await _thread.wait_to_finish()
+		_thread = null
 
 func _get_property_list() -> Array:
 	var list := []

--- a/addons/proton_scatter/src/stack/modifier_stack.gd
+++ b/addons/proton_scatter/src/stack/modifier_stack.gd
@@ -20,7 +20,10 @@ func start_update(scatter_node: ProtonScatter, domain) -> void:
 	var transforms = TransformList.new()
 
 	for modifier in stack:
-		await modifier.process_transforms(transforms, domain, scatter_node.global_seed)
+		if modifier.has_method(&"process_transforms"):
+			await modifier.process_transforms(transforms, domain, scatter_node.global_seed)
+		else:
+			printerr(modifier, " not inherit from 'base_modifier.gd'")
 
 	transforms_ready.emit(transforms)
 

--- a/addons/proton_scatter/src/stack/modifier_stack.gd
+++ b/addons/proton_scatter/src/stack/modifier_stack.gd
@@ -8,10 +8,11 @@ signal transforms_ready
 
 
 const ProtonScatter := preload("../scatter.gd")
-const TransformList = preload("../common/transform_list.gd")
+const TransformList := preload("../common/transform_list.gd")
+const BaseModifier := preload("../modifiers/base_modifier.gd")
 
 
-@export var stack: Array[Resource] = []
+@export var stack: Array[BaseModifier] = []
 
 var just_created := false
 
@@ -20,15 +21,12 @@ func start_update(scatter_node: ProtonScatter, domain) -> void:
 	var transforms = TransformList.new()
 
 	for modifier in stack:
-		if modifier.has_method(&"process_transforms"):
-			await modifier.process_transforms(transforms, domain, scatter_node.global_seed)
-		else:
-			printerr(modifier, " not inherit from 'base_modifier.gd'")
+		await modifier.process_transforms(transforms, domain, scatter_node.global_seed)
 
 	transforms_ready.emit(transforms)
 
 
-func add(modifier) -> void:
+func add(modifier: BaseModifier) -> void:
 	stack.push_back(modifier)
 	stack_changed.emit()
 
@@ -39,7 +37,7 @@ func move(old_index: int, new_index: int) -> void:
 	stack_changed.emit()
 
 
-func remove(modifier) -> void:
+func remove(modifier: BaseModifier) -> void:
 	if stack.has(modifier):
 		stack.erase(modifier)
 		stack_changed.emit()
@@ -51,7 +49,7 @@ func remove_at(index: int) -> void:
 		stack_changed.emit()
 
 
-func duplicate_modifier(modifier) -> void:
+func duplicate_modifier(modifier: BaseModifier) -> void:
 	var index: int = stack.find(modifier)
 	if index != -1:
 		var copy = modifier.get_copy()
@@ -66,7 +64,7 @@ func get_copy():
 	return copy
 
 
-func get_index(modifier) -> int:
+func get_index(modifier: BaseModifier) -> int:
 	return stack.find(modifier)
 
 

--- a/project.godot
+++ b/project.godot
@@ -11,9 +11,10 @@ config_version=5
 [application]
 
 config/name="ProtonScatter"
-config/tags=PackedStringArray("addon")
+run/main_scene="res://addons/proton_scatter/demos/showcase.tscn"
 config/features=PackedStringArray("4.1", "Forward Plus")
 config/icon="res://icon.svg"
+config/tags=PackedStringArray("addon")
 
 [debug]
 


### PR DESCRIPTION
Hi, I made a PR to fix some bugs I found:
- Ensure threads are awaited
- Make relax modifier work in headless mode
According to the [Godot Documentation](https://docs.godotengine.org/en/latest/classes/class_renderingserver.html#class-renderingserver-method-create-local-rendering-device), `create_local_rendering_device` method return `null` when we use the OpenGL backend or when we run Godot in headless mode
- Don't crash when a resource that doesn't inherit from `BaseModifier` is passed to the modifiers stack
- Added a simple Github workflow to ensure that the addon and the demo scene don't crash with Godot versions 4.0.3 and 4.1.0.
There are still a lot of errors, which can be seen in the [job logs](https://github.com/florianvazelle/scatter/actions/runs/5553686533). Is it the same when you use the addon?