### PR TITLE
Avoid degenerate case for splits size

### DIFF
--- a/addons/proton_scatter/src/scatter.gd
+++ b/addons/proton_scatter/src/scatter.gd
@@ -393,9 +393,9 @@ func _update_split_multimeshes() -> void:
 	var size = domain.bounds_local.size
 
 	var splits := Vector3i.ONE
-	splits.x = ceil(size.x / chunk_dimensions.x)
-	splits.y = ceil(size.y / chunk_dimensions.y)
-	splits.z = ceil(size.z / chunk_dimensions.z)
+	splits.x = max(1, ceil(size.x / chunk_dimensions.x))
+	splits.y = max(1, ceil(size.y / chunk_dimensions.y))
+	splits.z = max(1, ceil(size.z / chunk_dimensions.z))
 
 	if items.is_empty():
 		_discover_items()


### PR DESCRIPTION
Small fix regarding split sizes.
Split size could be zero in a dimension for example if everything is projected to a perfectly flat plane.
This essentially made the 3d array used in scatter.gd be 2d, which is not fun.