### PR TITLE
Shuffle and fixes

### DIFF
--- a/addons/proton_scatter/src/modifiers/create_along_edge_continuous.gd
+++ b/addons/proton_scatter/src/modifiers/create_along_edge_continuous.gd
@@ -51,7 +51,7 @@ func _init() -> void:
 
 
 # TODO: Use dichotomic search instead of fixed step length?
-func _process_transforms(transforms, domain, _seed) -> void:
+func _process_transforms(transforms, domain, seed) -> void:
 	var new_transforms: Array[Transform3D] = []
 	var curves: Array[Curve3D] = domain.get_edges()
 
@@ -85,6 +85,7 @@ func _process_transforms(transforms, domain, _seed) -> void:
 					break
 
 	transforms.append(new_transforms)
+	transforms.shuffle(seed)
 
 
 func get_projected_curve(curve: Curve3D, t: Transform3D) -> Curve3D:

--- a/addons/proton_scatter/src/modifiers/create_along_edge_even.gd
+++ b/addons/proton_scatter/src/modifiers/create_along_edge_even.gd
@@ -41,7 +41,7 @@ func _init() -> void:
 		to 0.05 at least.")
 
 
-func _process_transforms(transforms, domain, _seed) -> void:
+func _process_transforms(transforms, domain, seed) -> void:
 	spacing = max(_min_spacing, spacing)
 
 	var gt_inverse: Transform3D = domain.get_global_transform().affine_inverse()
@@ -76,3 +76,4 @@ func _process_transforms(transforms, domain, _seed) -> void:
 			new_transforms.push_back(t)
 
 	transforms.append(new_transforms)
+	transforms.shuffle(seed)


### PR DESCRIPTION
Adds missing shuffles to create along edge modifiers.

Replaces the `remove_at` call in project on geometry modifier. This makes the final processing of the modifier significantly faster on  large scatters.
Its behavior should be identical otherwise.