### PR TITLE
Bugfixes

### DIFF
--- a/addons/proton_scatter/src/modifiers/relax.gd
+++ b/addons/proton_scatter/src/modifiers/relax.gd
@@ -67,6 +67,9 @@ func _process_transforms(transforms, _domain, _seed) -> void:
 		var rd := RenderingServer.create_local_rendering_device()
 		if rd == null:
 			use_computeshader = false
+		else:
+			rd.free()
+			rd = null
 
 	if use_computeshader:
 		for iteration in iterations:

--- a/addons/proton_scatter/src/scatter.gd
+++ b/addons/proton_scatter/src/scatter.gd
@@ -378,7 +378,7 @@ func _update_multimeshes() -> void:
 			# Extra check because of how 'count' is calculated
 			if (offset + i) >= transforms_count:
 				mmi.multimesh.instance_count = i - 1
-				return
+				continue
 
 			t = item.process_transform(transforms.list[offset + i])
 			mmi.multimesh.set_instance_transform(i, t)
@@ -423,6 +423,8 @@ func _update_split_multimeshes() -> void:
 		var static_body := ProtonScatterUtil.get_collision_data(item)
 
 		for i in count:
+			if (offset + i) >= transforms_count:
+				continue
 			# both aabb and t are in mmi's local coordinates
 			var t = item.process_transform(transforms.list[offset + i])
 			var p_rel = (t.origin - aabb.position) / aabb.size


### PR DESCRIPTION
Found a few memory leaks and an indexing error.
In `scatter.gd` the return is replaced with continue. The last static_body is freed too this way.
In `relax.gd` the compute shader support left the created rendering devices behind. These were surprisingly large.
In update split multimesh there was a missing index check.