### PR TITLE
Rebuild and disable

### DIFF
--- a/addons/proton_scatter/src/scatter.gd
+++ b/addons/proton_scatter/src/scatter.gd
@@ -23,7 +23,8 @@ const ProtonScatterUtil := preload('./common/scatter_util.gd')
 @export var enabled := true:
 	set(val):
 		enabled = val
-		rebuild()
+		if is_ready:
+			rebuild()
 @export var global_seed := 0:
 	set(val):
 		global_seed = val

--- a/addons/proton_scatter/src/scatter.gd
+++ b/addons/proton_scatter/src/scatter.gd
@@ -20,6 +20,10 @@ const ProtonScatterUtil := preload('./common/scatter_util.gd')
 @export_category("ProtonScatter")
 
 @export_group("General")
+@export var enabled := true:
+	set(val):
+		enabled = val
+		rebuild()
 @export var global_seed := 0:
 	set(val):
 		global_seed = val
@@ -320,6 +324,11 @@ func rebuild(force_discover := false) -> void:
 # Scattered objects are stored under a Marker3D node called "ScatterOutput"
 # DON'T call this function directly outside of the 'rebuild()' function above.
 func _rebuild(force_discover) -> void:
+	if not enabled:
+		_clear_collision_data()
+		clear_output()
+		return
+
 	_perform_sanity_check()
 
 	if force_discover:

--- a/addons/proton_scatter/src/scatter.gd
+++ b/addons/proton_scatter/src/scatter.gd
@@ -126,6 +126,7 @@ var _dependency_parent
 var _physics_helper: ProtonScatterPhysicsHelper
 var _body_rid: RID
 var _collision_shapes: Array[RID]
+var _ignore_transform_notification = false
 
 
 func _ready() -> void:
@@ -193,11 +194,18 @@ func _get_configuration_warnings() -> PackedStringArray:
 
 
 func _notification(what):
+	if not is_ready:
+		return
 	match what:
 		NOTIFICATION_TRANSFORM_CHANGED:
+			if _ignore_transform_notification:
+				_ignore_transform_notification = false
+				return
 			_perform_sanity_check()
 			domain.compute_bounds()
 			rebuild.call_deferred()
+		NOTIFICATION_ENTER_WORLD:
+			_ignore_transform_notification = true
 
 
 func _set(property, value):

--- a/addons/proton_scatter/src/scatter.gd
+++ b/addons/proton_scatter/src/scatter.gd
@@ -327,6 +327,7 @@ func _rebuild(force_discover) -> void:
 	if not enabled:
 		_clear_collision_data()
 		clear_output()
+		build_completed.emit()
 		return
 
 	_perform_sanity_check()

--- a/addons/proton_scatter/src/scatter_shape.gd
+++ b/addons/proton_scatter/src/scatter_shape.gd
@@ -25,6 +25,8 @@ const ScatterUtil := preload('./common/scatter_util.gd')
 		update_gizmos()
 		ScatterUtil.request_parent_to_rebuild(self)
 
+var _ignore_transform_notification = false
+
 
 func _ready() -> void:
 	set_notify_transform(true)
@@ -33,7 +35,12 @@ func _ready() -> void:
 func _notification(what):
 	match what:
 		NOTIFICATION_TRANSFORM_CHANGED:
+			if _ignore_transform_notification:
+				_ignore_transform_notification = false
+				return
 			ScatterUtil.request_parent_to_rebuild(self)
+		NOTIFICATION_ENTER_WORLD:
+			_ignore_transform_notification = true
 
 
 func _set(property, _value):


### PR DESCRIPTION
I implemented a disable property for scatter nodes. 
I find it useful during testing during development and it provides an easy interface to toggle scatters while playing the game.

I also fixed the issue where the scatters triggered a rebuild when switching tabs.
It does not interfere with building the scatters on load.