### PR TITLE
fix: use node path to store scatter transforms

### DIFF
--- a/addons/proton_scatter/src/cache/scatter_cache.gd
+++ b/addons/proton_scatter/src/cache/scatter_cache.gd
@@ -88,7 +88,7 @@ func rebuild_cache() -> void:
 			continue # Move on to the next if still no results.
 
 		# Store the transforms in the cache.
-		_local_cache.store(s.name, s.transforms.list)
+		_local_cache.store(_scene_root.get_path_to(s), s.transforms.list)
 
 	ResourceSaver.save(_local_cache, cache_file)
 
@@ -109,7 +109,7 @@ func restore_cache(force_restore := false) -> void:
 
 		# Send the cached transforms to the scatter node.
 		var transforms = ProtonScatterTransformList.new()
-		transforms.list = _local_cache.get_transforms(s.name)
+		transforms.list = _local_cache.get_transforms(_scene_root.get_path_to(s))
 		s._perform_sanity_check()
 		s._on_transforms_ready(transforms)
 

--- a/addons/proton_scatter/src/common/cache_resource.gd
+++ b/addons/proton_scatter/src/common/cache_resource.gd
@@ -10,14 +10,14 @@ func clear() -> void:
 	data.clear()
 
 
-func store(node_name: String, transforms: Array[Transform3D]) -> void:
-	data[node_name] = transforms
+func store(node_path: String, transforms: Array[Transform3D]) -> void:
+	data[node_path] = transforms
 
 
-func get_transforms(node_name: String) -> Array[Transform3D]:
+func get_transforms(node_path: String) -> Array[Transform3D]:
 	var res: Array[Transform3D]
 
-	if node_name in data:
-		res.assign(data[node_name])
+	if node_path in data:
+		res.assign(data[node_path])
 
 	return res


### PR DESCRIPTION
Very simple change that fixes an issue in which scatter nodes with the same name cannot correctly cache their transforms by using the full node path as the cache index.

This is a good idea because there's no guarantee of name uniqueness for scatter nodes, e.g. in a structure like
* SomeNode
  * FlowerScatter
* SomeOtherNode
  * FlowerScatter
  
Instead of caching the transforms under the key "FlowerScatter", we should use "SomeNode/FlowerScatter" and "SomeOtherNode/FlowerScatter" as the keys.