### PR TITLE
Use deferred add child, cache meshinstance

### DIFF
--- a/addons/proton_scatter/src/common/scatter_util.gd
+++ b/addons/proton_scatter/src/common/scatter_util.gd
@@ -79,7 +79,6 @@ static func get_or_create_multimesh(item: ProtonScatterItem, count: int) -> Mult
 		item_root.add_child(mmi, true)
 
 		mmi.set_owner(item_root.owner)
-
 	if not mmi.multimesh:
 		mmi.multimesh = MultiMesh.new()
 
@@ -108,10 +107,16 @@ static func get_or_create_multimesh(item: ProtonScatterItem, count: int) -> Mult
 	return mmi
 
 
-static func get_or_create_multimesh_chunk(item: ProtonScatterItem, index: Vector3i, count) -> MultiMeshInstance3D:
+static func get_or_create_multimesh_chunk(item: ProtonScatterItem,
+										mesh_instance: MeshInstance3D,
+										index: Vector3i,
+										count: int)\
+										 -> MultiMeshInstance3D:
 	var item_root := get_or_create_item_root(item)
 	var chunk_name = "MultiMeshInstance3D" + "_%s_%s_%s"%[index.x, index.y, index.z]
 	var mmi: MultiMeshInstance3D = item_root.get_node_or_null(chunk_name)
+	if not mesh_instance:
+		return
 
 	if not mmi:
 		mmi = MultiMeshInstance3D.new()
@@ -119,9 +124,7 @@ static func get_or_create_multimesh_chunk(item: ProtonScatterItem, index: Vector
 		# if set_name is used after add_child it is crazy slow
 		# This doesn't make much sense but it is definitely the case.
 		# About a 100x slowdown was observed in this case
-		item_root.add_child(mmi, true)
-
-		mmi.set_owner(item_root.owner)
+		item_root.add_child.bind(mmi, true).call_deferred()
 
 	if not mmi.multimesh:
 		mmi.multimesh = MultiMesh.new()
@@ -129,10 +132,6 @@ static func get_or_create_multimesh_chunk(item: ProtonScatterItem, index: Vector
 	mmi.position = Vector3.ZERO
 	mmi.set_cast_shadows_setting(item.override_cast_shadow)
 	mmi.set_material_override(item.override_material)
-
-	var mesh_instance: MeshInstance3D = get_merged_meshes_from(item)
-	if not mesh_instance:
-		return
 
 	mmi.multimesh.instance_count = 0 # Set this to zero or you can't change the other values
 	mmi.multimesh.mesh = mesh_instance.mesh
@@ -145,8 +144,6 @@ static func get_or_create_multimesh_chunk(item: ProtonScatterItem, index: Vector
 	mmi.visibility_range_fade_mode 		= item.visibility_range_fade_mode
 
 	mmi.multimesh.instance_count = count
-
-	mesh_instance.queue_free()
 
 	return mmi
 

--- a/addons/proton_scatter/src/scatter.gd
+++ b/addons/proton_scatter/src/scatter.gd
@@ -453,6 +453,8 @@ func _update_split_multimeshes() -> void:
 
 		static_body.queue_free()
 
+		# Cache the mesh instance to be used for the chunks
+		var mesh_instance: MeshInstance3D = ProtonScatterUtil.get_merged_meshes_from(item)
 		# The relevant transforms are now ordered in chunks
 		for xi in splits.x:
 			for yi in splits.y:
@@ -460,7 +462,11 @@ func _update_split_multimeshes() -> void:
 					var chunk_elements = transform_chunks[xi][yi][zi].size()
 					if chunk_elements == 0:
 						continue
-					var mmi = ProtonScatterUtil.get_or_create_multimesh_chunk(item, Vector3i(xi, yi, zi), chunk_elements)
+					var mmi = ProtonScatterUtil.get_or_create_multimesh_chunk(
+													item, 
+													mesh_instance, 
+													Vector3i(xi, yi, zi), 
+													chunk_elements)
 					if not mmi:
 						continue
 
@@ -475,7 +481,7 @@ func _update_split_multimeshes() -> void:
 						t = transform_chunks[xi][yi][zi][i]
 						t.origin -= center
 						mmi.multimesh.set_instance_transform(i, t)
-
+		mesh_instance.queue_free()
 		offset += count
 
 


### PR DESCRIPTION
Using add_child with a deferred call seems to improve performance a lot.

Creating 40x40 chunks with 100k instances takes about 8 seconds with simple add_child and couple tenths with a deferred call. I'm not sure why, but it seems to be the case.

`get_merged_meshes_from(item)` is moved out to avoid repeated calculations.