### PR TITLE
Add option for basic multiplayer sync

### DIFF
--- a/addons/proton_scatter/src/scatter.gd
+++ b/addons/proton_scatter/src/scatter.gd
@@ -266,7 +266,7 @@ func _multiplayer_call(fn: Callable, arg = null):
 			fn.call()
 
 # Deletes what the Scatter node generated.
-@rpc("call_local")
+@rpc("call_local", "reliable")
 func clear_output() -> void:
 	if not output_root:
 		output_root = get_node_or_null("ScatterOutput")
@@ -279,7 +279,7 @@ func clear_output() -> void:
 	ProtonScatterUtil.ensure_output_root_exists(self)
 	_clear_collision_data()
 
-@rpc("call_local")
+@rpc("call_local", "reliable")
 func _clear_collision_data() -> void:
 	if _body_rid.is_valid():
 		PhysicsServer3D.free_rid(_body_rid)
@@ -700,7 +700,7 @@ func _on_transforms_ready(new_transforms: ProtonScatterTransformList) -> void:
 		_thread = null
 	_multiplayer_call(_do_transforms_ready, new_transforms.list)
 
-@rpc("call_local")
+@rpc("call_local", "reliable")
 func _do_transforms_ready(new_trs: Array):
 	var new_transforms = ProtonScatterTransformList.new()
 	new_transforms.list.assign(new_trs)

--- a/addons/proton_scatter/src/scatter.gd
+++ b/addons/proton_scatter/src/scatter.gd
@@ -253,11 +253,17 @@ func is_thread_running() -> bool:
 func get_physics_helper() -> ProtonScatterPhysicsHelper:
 	return _physics_helper
 
-func _multiplayer_call(fn: Callable):
+func _multiplayer_call(fn: Callable, arg = null):
 	if multiplayer_sync && is_multiplayer_authority() && !Engine.is_editor_hint():
-		fn.rpc()
+		if arg != null:
+			fn.rpc(arg)
+		else:
+			fn.rpc()
 	else:
-		fn.call()
+		if arg != null:
+			fn.call(arg)
+		else:
+			fn.call()
 
 # Deletes what the Scatter node generated.
 @rpc("call_local")
@@ -692,7 +698,7 @@ func _on_transforms_ready(new_transforms: ProtonScatterTransformList) -> void:
 	if is_thread_running():
 		await _thread.wait_to_finish()
 		_thread = null
-	_multiplayer_call(_do_transforms_ready.bind(new_transforms.list))
+	_multiplayer_call(_do_transforms_ready, new_transforms.list)
 
 @rpc("call_local")
 func _do_transforms_ready(new_trs: Array):

--- a/addons/proton_scatter/src/scatter.gd
+++ b/addons/proton_scatter/src/scatter.gd
@@ -345,7 +345,7 @@ func _rebuild(force_discover) -> void:
 		domain.discover_shapes(self)
 
 	if items.is_empty() or (domain.is_empty() and not modifier_stack.does_not_require_shapes()):
-		clear_output()
+		_multiplayer_call(clear_output)
 		push_warning("ProtonScatter warning: No items or shapes, abort")
 		return
 


### PR DESCRIPTION
(needed this for a project so figured I'd PR in case this is something you want :) )

Adds a new "Multiplayer Sync" option (false by default) on ProtonScatter node, which if enabled will sync the scatter output transforms from the multiplayer authority to clients

More specifically calls to these functions are synced via rpc:
- `_clear_collision_data`
- `clear_output`
- `_on_transforms_ready`

Tested in Godot 4.1.1 (in an unreleased project)
Might be worth making a dedicated test setup, idk how thorough you want to be

Demo (left is server with `enabled` field being toggled, right is client):

https://github.com/HungryProton/scatter/assets/13819558/b2b1e5af-ee76-4653-88f3-6f5c7cd5bc70

Some notes:
- I'm not particularly familiar with this addon's code so not sure if there's other things that might cause issues with this
- When using this you probably want to set `enabled` to false on clients, otherwise they will also try to scatter locally.
  - (it'd be possible to make it so clients ignore `enabled`/`rebuild`/etc if multiplayer sync is on, if that's desired)
- The `_multiplayer_call` function looks kinda dumb, but I was trying to avoid using `bind` since iirc `rpc` only works with `bind` on 4.1.1+
- Open to naming suggestions (ie. `multiplayer_sync`/"Multiplayer Sync", `_multiplayer_call`, `_do_transforms_ready`)