### PR TITLE
fixed gitattributes so it works correctly on the asset library

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,7 @@
-# Normalize EOL for all files that Git considers text files.
+# Normalize line endings for all files that Git considers text files.
 * text=auto eol=lf
 
-/.gitattributes     export-ignore
-/.gitignore         export-ignore
-/LICENSE.md            export-ignore
-/README.md          export-ignore
-/project.godot      export-ignore
-/icon.png 	    export-ignore
-/logo.svg	export-ignore
-/logo.png	export-ignore
-/.github	export-ignore
+# Only include the addons folder when downloading from the Asset Library.
+/**        export-ignore
+/addons    !export-ignore
+/addons/** !export-ignore


### PR DESCRIPTION
I wanted to test out your addon and couldn't, because it dumps files into the root of the end user's project, so I fixed the gitattributes file for you as per godot documented guidelines on posting to the asset library:
https://docs.godotengine.org/en/stable/community/asset_library/submitting_to_assetlib.html#recommendations

If you accept and update your asset library submission, people will actually be able to use your addon now.