### PR TITLE
Check if tree exists to avoid null exception when processing frame 

### DIFF
--- a/addons/proton_scatter/src/scatter.gd
+++ b/addons/proton_scatter/src/scatter.gd
@@ -721,5 +721,11 @@ func _on_transforms_ready(new_transforms: ProtonScatterTransformList) -> void:
 
 	update_gizmos()
 	build_version += 1
-	await get_tree().process_frame
+	
+	var tree = get_tree()
+
+	if not tree:
+		return
+
+	await tree.process_frame
 	build_completed.emit()

--- a/addons/proton_scatter/src/scatter.gd
+++ b/addons/proton_scatter/src/scatter.gd
@@ -722,10 +722,9 @@ func _on_transforms_ready(new_transforms: ProtonScatterTransformList) -> void:
 	update_gizmos()
 	build_version += 1
 	
-	var tree = get_tree()
-
-	if not tree:
+	if not is_inside_tree():
 		return
+	
+	await get_tree().process_frame
 
-	await tree.process_frame
 	build_completed.emit()


### PR DESCRIPTION
**Problem**
freeing a child node (with a scatter node in it) after removing it from a tree causes null exception.

**Description**
Assume I have a tree, with a child node in it. This child node has a scatter node in it. If I try to remove the child node from the tree, and then try to free the node, there will be a null exception in ```_on_transforms_ready``` at ```await get_tree().process_frame```, because the node is no longer in a tree.

**Solution**
Check if the tree exists before processing frame.

I'm not sure if this is the correct way to do it, but it lets me do what I wanted to do (free object after removing it from a tree)