### PR TITLE
fix: create the default cache folder only inside the editor

### DIFF
--- a/addons/proton_scatter/src/cache/scatter_cache.gd
+++ b/addons/proton_scatter/src/cache/scatter_cache.gd
@@ -44,8 +44,12 @@ func _ready() -> void:
 
 	# Check if cache_file is empty, indicating the default case
 	if cache_file.is_empty():
-		# Ensure the cache folder exists
-		_ensure_cache_folder_exists()
+		if Editor.is_editor_hint():
+			# Ensure the cache folder exists
+			_ensure_cache_folder_exists()
+		else:
+			printerr("ProtonScatter error: You load a ScatterCache node with an empty cache file attribute. Outside of the editor, the addon can't set a default value. Please open the scene in the editor and set a default value.")
+			return
 
 		# Retrieve the scene name to create a unique recognizable name
 		var scene_path: String = _scene_root.get_scene_file_path()

--- a/addons/proton_scatter/src/cache/scatter_cache.gd
+++ b/addons/proton_scatter/src/cache/scatter_cache.gd
@@ -40,22 +40,26 @@ func _ready() -> void:
 	if not is_inside_tree():
 		return
 
-	_ensure_cache_folder_exists()
-
 	_scene_root = _get_local_scene_root(self)
 
-	# By default, set the cache path to the cache folder, with a unique recognizable name
+	# Check if cache_file is empty, indicating the default case
 	if cache_file.is_empty():
+		# Ensure the cache folder exists
+		_ensure_cache_folder_exists()
+
+		# Retrieve the scene name to create a unique recognizable name
 		var scene_path: String = _scene_root.get_scene_file_path()
 		var scene_name: String
 
-		# Set a random name if we can't find the current scene
+		# If the scene path is not available, set a random name
 		if scene_path.is_empty():
 			scene_name = str(randi())
 		else:
+			# Use the base name of the scene file and append a hash to avoid collisions
 			scene_name = scene_path.get_file().get_basename()
-			scene_name += "_" + str(scene_path.hash()) # Prevents name collisions
+			scene_name += "_" + str(scene_path.hash())
 
+		# Set the cache path to the cache folder, incorporating the scene name
 		cache_file = DEFAULT_CACHE_FOLDER.get_basename().path_join(scene_name + "_scatter_cache.res")
 		return
 


### PR DESCRIPTION
Hi, I submit a small bug fix :wave: 

I don't store my cache file in the default cache folder, so when I export my game and run it, I get an error like this:
```
ERROR: Could not create directory: res://addons
   at: make_dir_recursive (core/io/dir_access.cpp:180)
```

I think that creating a default cache folder is only necessary when defining a default path to the cache file.