### PR TITLE
fix: use ResourceLoader to check if the cache exists

### DIFF
--- a/addons/proton_scatter/src/cache/scatter_cache.gd
+++ b/addons/proton_scatter/src/cache/scatter_cache.gd
@@ -123,7 +123,7 @@ func update_cache() -> void:
 
 func restore_cache() -> void:
 	# Load the cache file if it exists
-	if not FileAccess.file_exists(cache_file):
+	if not ResourceLoader.exists(cache_file):
 		printerr("Could not find cache file ", cache_file)
 		return
 	


### PR DESCRIPTION
Hi, I submit a new small bug fix, related to the scatter cache script :wave: 

When I run my exported game, the scatter cache don't find my cache file with a `FileAccess.file_exists`.

Accordingly to the godot documentation `ResourceLoader` expose an [`exists`](https://github.com/HungryProton/scatter/pull/180) method allowing to check if a resource file exists. 
