### PR TITLE
fix: avoid infinite loop in physics_helper when not in tree

### DIFF
--- a/addons/proton_scatter/src/common/physics_helper.gd
+++ b/addons/proton_scatter/src/common/physics_helper.gd
@@ -31,6 +31,13 @@ func execute(queries: Array) -> Array[Dictionary]:
 		printerr("ProtonScatter error: Calling execute on a PhysicsHelper before it's ready, this should not happen.")
 		return []
 
+	# Don't execute physics queries, if the node is not inside the tree.
+	# This avoids infinite loops, because the _physics_process will never be executed.
+	# This happens when the Scatter node is removed, while it perform a rebuild with a Thread.
+	if not is_inside_tree():
+		printerr("ProtonScatter error: Calling execute on a PhysicsHelper while the node is not inside the tree.")
+		return []
+
 	# Clear previous job if any
 	_queries.clear()
 


### PR DESCRIPTION
Hi, I submit a bug fix, related to the physics helper script 👋

As said in https://github.com/HungryProton/scatter/issues/187, when a Scatter node is removed, while it perform a rebuild with a Thread, it causes an infinite loop.

I've found that this only happens when the "Project On Colliders" modifier is used, because the modifier tries to execute physical requests, while the `ProtonScatterPhysicsHelper` is not in the tree at the time.

So the logic waiting for `_physics_process` to execute queries never ends, because the `_physics_process` is never executed.