### PR TITLE
Update domain.gd

### DIFF
--- a/addons/proton_scatter/src/common/domain.gd
+++ b/addons/proton_scatter/src/common/domain.gd
@@ -28,6 +28,7 @@ class DomainShapeInfo:
 			return shape.is_point_inside(point, t)
 		else:
 			return false	
+	
 	func get_corners_global() -> Array:
 		return shape.get_corners_global(node.get_global_transform())
 

--- a/addons/proton_scatter/src/common/domain.gd
+++ b/addons/proton_scatter/src/common/domain.gd
@@ -28,7 +28,8 @@ class DomainShapeInfo:
 			return shape.is_point_inside(point, t)
 		else:
 			return false	
-
+	func get_corners_global() -> Array:
+		return shape.get_corners_global(node.get_global_transform())
 
 # A polygon made of one outer boundary and one or multiple holes (inner polygons)
 class ComplexPolygon:

--- a/addons/proton_scatter/src/common/domain.gd
+++ b/addons/proton_scatter/src/common/domain.gd
@@ -23,11 +23,11 @@ class DomainShapeInfo:
 
 	func is_point_inside(point: Vector3, local: bool) -> bool:
 		var t: Transform3D
-		t = node.get_transform() if local else node.get_global_transform()
-		return shape.is_point_inside(point, t)
-
-	func get_corners_global() -> Array:
-		return shape.get_corners_global(node.get_global_transform())
+		if is_instance_valid(node):
+			t = node.get_transform() if local else node.get_global_transform()
+			return shape.is_point_inside(point, t)
+		else:
+			return false	
 
 
 # A polygon made of one outer boundary and one or multiple holes (inner polygons)


### PR DESCRIPTION
If node is released from memory is_point_inside fails on node.get_transform() call creates infinite loop and, uses up all memory and crashes the editor. Added is_instance_valid check to prevent it