### PR TITLE
Lazy load the relax shader

### DIFF
--- a/addons/proton_scatter/src/modifiers/relax.gd
+++ b/addons/proton_scatter/src/modifiers/relax.gd
@@ -2,7 +2,7 @@
 extends "base_modifier.gd"
 
 
-const shader_file := preload("./compute_shaders/compute_relax.glsl")
+static var shader_file: RDShaderFile
 
 
 @export var iterations : int = 3
@@ -123,7 +123,7 @@ func compute_closest(transforms) -> PackedVector3Array:
 	var padded_num_vecs = ceil(float(transforms.size()) / 64.0) * 64
 	var padded_num_floats = padded_num_vecs * 4
 	var rd := RenderingServer.create_local_rendering_device()
-	var shader_spirv: RDShaderSPIRV = shader_file.get_spirv()
+	var shader_spirv: RDShaderSPIRV = get_shader_file().get_spirv()
 	var shader := rd.shader_create_from_spirv(shader_spirv)
 	# Prepare our data. We use vec4 floats in the shader, so we need 32 bit.
 	var input := PackedFloat32Array()
@@ -183,3 +183,9 @@ func compute_closest(transforms) -> PackedVector3Array:
 		rd.free()
 		rd = null
 	return retval
+
+func get_shader_file() -> RDShaderFile:
+	if shader_file == null:
+		shader_file = load(get_script().resource_path.get_base_dir() + "/compute_shaders/compute_relax.glsl")
+	
+	return shader_file


### PR DESCRIPTION
There are 3 reasons for doing this:

1. Users that don't make use of the compute shader don't need to load the shader saving resources and improving performance.
2. The tradeoff for lazy load on a static variable vs preload should be negligible given that it will be loaded the first time it is needed and persist through the rest of the game.
3. Godot currently can't export glsl shaders in headless mode.  I don't need glsl at the moment but I do want scatter.  Godot plans to fix this in the 4.4 release but here is the issue: https://github.com/godotengine/godot/issues/94734