### PR TITLE
Add more class_names (ProtonScatter, ProtonScatterShape, ProtonScatterItem, ProtonScatterModifierStack)

### DIFF
--- a/addons/proton_scatter/plugin.gd
+++ b/addons/proton_scatter/plugin.gd
@@ -2,8 +2,6 @@
 extends EditorPlugin
 
 
-const ProtonScatter := preload("./src/scatter.gd")
-const ProtonScatterShape := preload("./src/scatter_shape.gd")
 const ModifierStackPlugin := preload("./src/stack/inspector_plugin/modifier_stack_plugin.gd")
 const ScatterGizmoPlugin := preload("./src/scatter_gizmo_plugin.gd")
 const ShapeGizmoPlugin := preload("./src/shapes/gizmos_plugin/shape_gizmo_plugin.gd")

--- a/addons/proton_scatter/src/cache/scatter_cache.gd
+++ b/addons/proton_scatter/src/cache/scatter_cache.gd
@@ -13,7 +13,6 @@ extends Node
 
 const DEFAULT_CACHE_FOLDER := "res://addons/proton_scatter/cache/"
 
-const ProtonScatter := preload("res://addons/proton_scatter/src/scatter.gd")
 const ProtonScatterTransformList := preload("../common/transform_list.gd")
 
 

--- a/addons/proton_scatter/src/common/domain.gd
+++ b/addons/proton_scatter/src/common/domain.gd
@@ -11,8 +11,6 @@ extends RefCounted
 # An instance of this class is passed to the modifiers during a rebuild.
 
 
-const ProtonScatter := preload("../scatter.gd")
-const ProtonScatterShape := preload("../scatter_shape.gd")
 const BaseShape := preload("../shapes/base_shape.gd")
 const Bounds := preload("../common/bounds.gd")
 

--- a/addons/proton_scatter/src/common/scatter_util.gd
+++ b/addons/proton_scatter/src/common/scatter_util.gd
@@ -4,11 +4,6 @@ extends Node
 # utility functions are written here (only the functions that don't disturb
 # reading the core code, mostly data validation and other verbose checks).
 
-
-const ProtonScatter := preload("../scatter.gd")
-const ProtonScatterItem := preload("../scatter_item.gd")
-const ModifierStack := preload("../stack/modifier_stack.gd")
-
 ### SCATTER UTILITY FUNCTIONS ###
 
 

--- a/addons/proton_scatter/src/modifiers/proxy.gd
+++ b/addons/proton_scatter/src/modifiers/proxy.gd
@@ -2,10 +2,6 @@
 extends "base_modifier.gd"
 
 
-const ProtonScatter := preload("../scatter.gd")
-const ModifierStack := preload("../stack/modifier_stack.gd")
-
-
 @export_node_path var scatter_node: NodePath
 @export var auto_rebuild := true:
 	set(val):
@@ -66,7 +62,7 @@ func _process_transforms(transforms, domain, _seed) -> void:
 		return
 
 	if _source_node.modifier_stack:
-		var stack: ModifierStack = _source_node.modifier_stack.get_copy()
+		var stack: ProtonScatterModifierStack = _source_node.modifier_stack.get_copy()
 		var results = await stack.start_update(domain.get_root(), domain)
 		transforms.append(results.list)
 

--- a/addons/proton_scatter/src/presets/presets.gd
+++ b/addons/proton_scatter/src/presets/presets.gd
@@ -5,8 +5,6 @@ extends Popup
 const PRESETS_PATH = "res://addons/proton_scatter/presets"
 const PresetEntry := preload("./preset_entry.tscn")
 const ProtonScatterUtil := preload('../common/scatter_util.gd')
-const ProtonScatterItem := preload('../scatter_item.gd')
-const ProtonScatterShape := preload('../scatter_shape.gd')
 
 var _scatter_node
 var _ideal_popup_size: Vector2i

--- a/addons/proton_scatter/src/scatter.gd
+++ b/addons/proton_scatter/src/scatter.gd
@@ -1,4 +1,5 @@
 @tool
+class_name ProtonScatter
 extends Node3D
 
 
@@ -9,10 +10,7 @@ signal build_completed
 
 # Includes
 const ProtonScatterDomain := preload("./common/domain.gd")
-const ProtonScatterItem := preload("./scatter_item.gd")
-const ProtonScatterModifierStack := preload("./stack/modifier_stack.gd")
 const ProtonScatterPhysicsHelper := preload("./common/physics_helper.gd")
-const ProtonScatterShape := preload("./scatter_shape.gd")
 const ProtonScatterTransformList := preload("./common/transform_list.gd")
 const ProtonScatterUtil := preload('./common/scatter_util.gd')
 

--- a/addons/proton_scatter/src/scatter_gizmo_plugin.gd
+++ b/addons/proton_scatter/src/scatter_gizmo_plugin.gd
@@ -8,7 +8,6 @@ extends EditorNode3DGizmoPlugin
 # Also displays the domain edges if one of its modifiers is using this data.
 
 
-const ProtonScatter := preload("./scatter.gd")
 const LoadingAnimation := preload("../icons/loading/m_loading.tres")
 
 var _loading_mesh: Mesh

--- a/addons/proton_scatter/src/scatter_item.gd
+++ b/addons/proton_scatter/src/scatter_item.gd
@@ -1,4 +1,5 @@
 @tool
+class_name ProtonScatterItem
 extends Node3D
 
 

--- a/addons/proton_scatter/src/scatter_shape.gd
+++ b/addons/proton_scatter/src/scatter_shape.gd
@@ -1,4 +1,5 @@
 @tool
+class_name ProtonScatterShape
 extends Node3D
 
 

--- a/addons/proton_scatter/src/shapes/gizmos_plugin/path_gizmo.gd
+++ b/addons/proton_scatter/src/shapes/gizmos_plugin/path_gizmo.gd
@@ -2,8 +2,6 @@
 extends "gizmo_handler.gd"
 
 
-const ProtonScatter := preload("res://addons/proton_scatter/src/scatter.gd")
-const ProtonScatterShape := preload("res://addons/proton_scatter/src/scatter_shape.gd")
 const ProtonScatterEventHelper := preload("res://addons/proton_scatter/src/common/event_helper.gd")
 const PathPanel := preload("./components/path_panel.gd")
 

--- a/addons/proton_scatter/src/stack/modifier_stack.gd
+++ b/addons/proton_scatter/src/stack/modifier_stack.gd
@@ -1,4 +1,5 @@
 @tool
+class_name ProtonScatterModifierStack
 extends Resource
 
 
@@ -7,7 +8,6 @@ signal value_changed
 signal transforms_ready
 
 
-const ProtonScatter := preload("../scatter.gd")
 const TransformList := preload("../common/transform_list.gd")
 
 


### PR DESCRIPTION
I'm trying to do some programmatic access to `ProtonScatter` and adding these class names gave much better type checking against the add-on.

This also lets a lot of the `preload`s be removed since these classes can just be accessed by name now.