### PR TITLE
fix ScatterCache synchronization issue

### DIFF
--- a/addons/proton_scatter/src/cache/scatter_cache.gd
+++ b/addons/proton_scatter/src/cache/scatter_cache.gd
@@ -147,7 +147,7 @@ func restore_cache() -> void:
 		return
 
 	if is_inside_tree():
-		_load_cache_threaded(cache_file)
+		await _load_cache_threaded(cache_file)
 	else:
 		_local_cache = load(cache_file)
 	if not _local_cache:


### PR DESCRIPTION
Fix ScatterCache synchronization issue when it is on threaded loading. Need to await the cache loaded on the other thread then null check on the _local_cache.