### PR TITLE
Fix setup of use_chunks and chunk_dimensions ingame

### DIFF
--- a/addons/proton_scatter/src/scatter.gd
+++ b/addons/proton_scatter/src/scatter.gd
@@ -72,6 +72,7 @@ var chunk_dimensions := Vector3.ONE * 15.0:
 		chunk_dimensions.y = max(val.y, 1.0)
 		chunk_dimensions.z = max(val.z, 1.0)
 		if is_ready:
+			notify_property_list_changed()
 			rebuild.call_deferred()
 
 ## If enabled, creates static collision shapes for scattered objects.
@@ -263,18 +264,20 @@ func _notification(what):
 
 
 func _set(property, value):
+	# use_chunks and chunk_dimensions need to be updated regardless of being in-editor
+	# or not, otherwise they will always use their defaults ingame (on, [15.0, 15.0, 15.0])
+	if property == "Performance/use_chunks":
+		use_chunks = value
+
+	elif property == "Performance/chunk_dimensions":
+		chunk_dimensions = value
+
 	if not Engine.is_editor_hint():
 		return false
 
 	# Workaround to detect when the node was duplicated from the editor.
 	if property == "transform":
 		_on_node_duplicated.call_deferred()
-
-	elif property == "Performance/use_chunks":
-		use_chunks = value
-
-	elif property == "Performance/chunk_dimensions":
-		chunk_dimensions = value
 
 	# Backward compatibility.
 	# Convert the value of previous property "use_instancing" into the proper render_mode.

--- a/addons/proton_scatter/src/scatter_item.gd
+++ b/addons/proton_scatter/src/scatter_item.gd
@@ -107,8 +107,6 @@ const ScatterUtil := preload('./common/scatter_util.gd')
 ## Specifies which 3D render layers the scattered instances will be visible on.
 ## Uses the standard Godot layer system where each bit represents a layer.
 ## Useful for controlling which instances are visible to different cameras.
-@export_flags_3d_render var visibility_layers: int = 1
-
 @export_flags_3d_render var visibility_layers: int = 1:
 	set(val):
 		visibility_layers = val

--- a/addons/proton_scatter/src/scatter_item.gd
+++ b/addons/proton_scatter/src/scatter_item.gd
@@ -109,12 +109,31 @@ const ScatterUtil := preload('./common/scatter_util.gd')
 ## Useful for controlling which instances are visible to different cameras.
 @export_flags_3d_render var visibility_layers: int = 1
 
-@export var visibility_range_begin : float = 0
-@export var visibility_range_begin_margin : float = 0
-@export var visibility_range_end : float = 0
-@export var visibility_range_end_margin : float = 0
+@export_flags_3d_render var visibility_layers: int = 1:
+	set(val):
+		visibility_layers = val
+		ScatterUtil.request_parent_to_rebuild(self)
+@export var visibility_range_begin : float = 0:
+	set(val):
+		visibility_range_begin = val
+		ScatterUtil.request_parent_to_rebuild(self)
+@export var visibility_range_begin_margin : float = 0:
+	set(val):
+		visibility_range_begin_margin = val
+		ScatterUtil.request_parent_to_rebuild(self)
+@export var visibility_range_end : float = 0:
+	set(val):
+		visibility_range_end = val
+		ScatterUtil.request_parent_to_rebuild(self)
+@export var visibility_range_end_margin : float = 0:
+	set(val):
+		visibility_range_end_margin = val
+		ScatterUtil.request_parent_to_rebuild(self)
 #TODO what is a nicer way to expose this?
-@export_enum("Disabled:0", "Self:1") var visibility_range_fade_mode = 0
+@export_enum("Disabled:0", "Self:1") var visibility_range_fade_mode = 0:
+	set(val):
+		visibility_range_fade_mode = val
+		ScatterUtil.request_parent_to_rebuild(self)
 
 @export_group("Level Of Detail", "lod_")
 


### PR DESCRIPTION
Previously, these would only be updated if the script detected that it was being ran in-editor, which allowed adjusting chunk usage and dimensions fine there (provided you changed another setting that calls for a scatter update, as dimensions changes didn't do it by themselves). However, once ingame, the updated values wouldn't apply, resulting in the defaults being used.

This commit fixes that, while also adding changes to make scatter update whenever the chunk dimensions and the scatter item's visibility ranges are altered, allowing for direct ingame and editor changes without needing to alter other, potentially unrelated settings to force scatter to update.

`scatter.gd` is the one containing the direct fix for issue #170, whereas `scatter_item.gd` has the additions to allow visibility ranges to be changed ingame via a script. I'm open for discussions in case anything needs to be changed.

Tested in Godot v4.5 and works fine there by transplanting these changes into the scatter version from AssetLib.