### PR TITLE
Some improvements to ScatterCache

### DIFF
--- a/addons/proton_scatter/src/cache/scatter_cache.gd
+++ b/addons/proton_scatter/src/cache/scatter_cache.gd
@@ -43,7 +43,7 @@ var _scene_root: Node
 var _scatter_nodes: Dictionary #Key: ProtonScatter, Value: cached version
 var _local_cache_changed := false
 
-var saveThread = Thread.new()
+var _save_thread = Thread.new()
 
 func _ready() -> void:
 	if not is_inside_tree():
@@ -99,9 +99,10 @@ func clear_cache() -> void:
 	if dbg_disable_thread:
 		save_cache()
 	else:
-		if !saveThread.is_alive():
-			saveThread.wait_to_finish()
-			saveThread.start(save_cache)
+		if !_save_thread.is_alive():
+			if _save_thread.is_started():
+				_save_thread.wait_to_finish()
+			_save_thread.start(save_cache)
 
 
 func update_cache() -> void:
@@ -141,9 +142,10 @@ func update_cache() -> void:
 	if dbg_disable_thread:
 		save_cache()
 	else:
-		if !saveThread.is_alive():
-			saveThread.wait_to_finish()
-			saveThread.start(save_cache)
+		if !_save_thread.is_alive():
+			if _save_thread.is_started():
+				_save_thread.wait_to_finish()
+			_save_thread.start(save_cache)
 
 	_local_cache_changed = false
 
@@ -256,4 +258,5 @@ func save_cache() -> void:
 
 
 func _exit_tree():
-	saveThread.wait_to_finish()
+	if _save_thread.is_started():
+		_save_thread.wait_to_finish()

--- a/addons/proton_scatter/src/cache/scatter_cache.gd
+++ b/addons/proton_scatter/src/cache/scatter_cache.gd
@@ -33,8 +33,8 @@ signal cache_restored
 
 @export_group("Debug", "dbg_")
 
-## This parameter is primarily intended for debugging purposes, as loading large cache
-## files on the main thread can cause the editor to become unresponsive.
+## This parameter is primarily intended for debugging purposes, as saving/loading 
+## large cache files on the main thread will cause the editor to become unresponsive.
 @export var dbg_disable_thread := false
 
 # The resource where transforms are actually stored
@@ -43,6 +43,7 @@ var _scene_root: Node
 var _scatter_nodes: Dictionary #Key: ProtonScatter, Value: cached version
 var _local_cache_changed := false
 
+var saveThread = Thread.new()
 
 func _ready() -> void:
 	if not is_inside_tree():
@@ -56,7 +57,7 @@ func _ready() -> void:
 			# Ensure the cache folder exists
 			_ensure_cache_folder_exists()
 		else:
-			printerr("ProtonScatter error: You load a ScatterCache node with an empty cache file attribute. Outside of the editor, the addon can't set a default value. Please open the scene in the editor and set a default value.")
+			printerr("ProtonScatter error: You loaded a ScatterCache node with an empty cache file attribute. Outside of the editor, the addon can't set a default value. Please open the scene in the editor and set a default value.")
 			return
 
 		# Retrieve the scene name to create a unique recognizable name
@@ -93,7 +94,14 @@ func _notification(what):
 
 func clear_cache() -> void:
 	_scatter_nodes.clear()
-	_local_cache = null
+	_local_cache.clear()
+	
+	if dbg_disable_thread:
+		save_cache()
+	else:
+		if !saveThread.is_alive():
+			saveThread.wait_to_finish()
+			saveThread.start(save_cache)
 
 
 func update_cache() -> void:
@@ -130,12 +138,14 @@ func update_cache() -> void:
 	if not _local_cache_changed:
 		return
 
-	# TODO: Save large files on a thread
-	var err = ResourceSaver.save(_local_cache, cache_file)
-	_local_cache_changed = false
+	if dbg_disable_thread:
+		save_cache()
+	else:
+		if !saveThread.is_alive():
+			saveThread.wait_to_finish()
+			saveThread.start(save_cache)
 
-	if err != OK:
-		printerr("ProtonScatter error: Failed to save the cache file. Code: ", err)
+	_local_cache_changed = false
 
 
 func restore_cache() -> void:
@@ -145,7 +155,10 @@ func restore_cache() -> void:
 		return
 
 	if is_inside_tree():
-		await _load_cache_threaded(cache_file)
+		if dbg_disable_thread:
+			_load_cache(cache_file)
+		else:
+			await _load_cache_threaded(cache_file)
 	else:
 		_local_cache = load(cache_file)
 	if not _local_cache:
@@ -215,6 +228,9 @@ func _ensure_cache_folder_exists() -> void:
 		DirAccess.make_dir_recursive_absolute(DEFAULT_CACHE_FOLDER)
 
 
+func _load_cache(cache_file_path: String) -> void:
+	_local_cache = ResourceLoader.load(cache_file)
+
 func _load_cache_threaded(cache_file_path: String) -> void:
 	# Cache files are large, load on a separate thread when possible
 	ResourceLoader.load_threaded_request(cache_file)
@@ -230,3 +246,14 @@ func _load_cache_threaded(cache_file_path: String) -> void:
 				break
 
 	_local_cache = ResourceLoader.load_threaded_get(cache_file)
+
+
+func save_cache() -> void:
+	var err = ResourceSaver.save(_local_cache, cache_file)
+
+	if err != OK:
+		printerr("ProtonScatter error: Failed to save the cache file. Code: ", err)
+
+
+func _exit_tree():
+	saveThread.wait_to_finish()


### PR DESCRIPTION
After expanding my main scene (and littering it with objects populated by scatter), i began to notice that the cache was taking a while to save, freezing the whole editor in the process.

This commit solves that by saving the cache file on a separate thread unless the "dbg_disable_thread" variable is enabled on the ScatterCache node... the "Clear Cache" button now has a use as well, as it now saves a cleared cache file (that is, no transforms or scatter nodes) onto the disk. I can't think of an use for it that's not debugging the saved file or cleaning up garbage data on it, so that's why it saves an effectively empty file.

Also, loading the cache file can now be done on the main thread if "dbg_disable_thread" is set to true as well.


I haven't found any issues on my end after using these changes for about a week, but i'm still open to discussions and suggestions.