### PR TITLE
Fix Relax Position compute shader bounds for Metal stability

### DIFF
--- a/addons/proton_scatter/src/modifiers/compute_shaders/compute_relax.glsl
+++ b/addons/proton_scatter/src/modifiers/compute_shaders/compute_relax.glsl
@@ -16,21 +16,32 @@ layout(set = 0, binding = 1, std430) restrict buffer BufferOut {
 }
 buffer_out;
 
+// Number of real points in the input buffer (excluding padding).
+layout(set = 0, binding = 2, std430) readonly buffer Params {
+    int point_count;
+}
+params;
+
 // The code we want to execute in each invocation
 void main() {
-    int last_element_index = buffer_in.data.length();
     // Unique index for each element
     uint workgroupSize = gl_WorkGroupSize.x * gl_WorkGroupSize.y * gl_WorkGroupSize.z;
     uint index = gl_WorkGroupID.x * workgroupSize + gl_LocalInvocationIndex;
+    int point_count = params.point_count;
+
+    // Ignore padded invocations and invalid counts.
+    if (point_count <= 0 || index >= uint(point_count)) {
+        return;
+    }
 
     vec3 infvec = vec3(1, 1, 1) * 999999; // vector approaching "infinity"
     vec3 closest = infvec; // initialize closest to infinity
     vec3 origin = buffer_in.data[index].xyz;
 
-    for(int i = 0; i <= last_element_index; i++){
+    for (int i = 0; i < point_count; i++) {
         vec3 newvec = buffer_in.data[i].xyz;
 
-        if (i == index) continue; // ignore self
+        if (uint(i) == index) continue; // ignore self
 
         float olddist = length(closest - origin);
         float newdist = length(newvec - origin);

--- a/addons/proton_scatter/src/modifiers/relax.gd
+++ b/addons/proton_scatter/src/modifiers/relax.gd
@@ -136,9 +136,12 @@ func compute_closest(transforms) -> PackedVector3Array:
 	input.resize(padded_num_floats) # indexing in the compute shader requires padding
 	var input_bytes := input.to_byte_array()
 	var output_bytes := input_bytes.duplicate()
+	var params := PackedInt32Array([transforms.size()])
+	var params_bytes := params.to_byte_array()
 	# Create a storage buffer that can hold our float values.
 	var buffer_in := rd.storage_buffer_create(input_bytes.size(), input_bytes)
 	var buffer_out := rd.storage_buffer_create(output_bytes.size(), output_bytes)
+	var buffer_params := rd.storage_buffer_create(params_bytes.size(), params_bytes)
 
 	# Create a uniform to assign the buffer to the rendering device
 	var uniform_in := RDUniform.new()
@@ -150,8 +153,12 @@ func compute_closest(transforms) -> PackedVector3Array:
 	uniform_out.uniform_type = RenderingDevice.UNIFORM_TYPE_STORAGE_BUFFER
 	uniform_out.binding = 1 # this needs to match the "binding" in our shader file
 	uniform_out.add_id(buffer_out)
+	var uniform_params := RDUniform.new()
+	uniform_params.uniform_type = RenderingDevice.UNIFORM_TYPE_STORAGE_BUFFER
+	uniform_params.binding = 2 # this needs to match the "binding" in our shader file
+	uniform_params.add_id(buffer_params)
 	# the last parameter (the 0) needs to match the "set" in our shader file
-	var uniform_set := rd.uniform_set_create([uniform_in, uniform_out], shader, 0)
+	var uniform_set := rd.uniform_set_create([uniform_in, uniform_out, uniform_params], shader, 0)
 
 	# Create a compute pipeline
 	var pipeline := rd.compute_pipeline_create(shader)
@@ -180,6 +187,7 @@ func compute_closest(transforms) -> PackedVector3Array:
 		rd.free_rid(shader)
 		rd.free_rid(buffer_in)
 		rd.free_rid(buffer_out)
+		rd.free_rid(buffer_params)
 		rd.free()
 		rd = null
 	return retval


### PR DESCRIPTION
## Summary
- fix an out-of-bounds read in `compute_relax.glsl` by iterating with `< point_count` instead of reading past buffer length
- pass the real transform count from `relax.gd` to the compute shader (new params storage buffer at binding 2)
- guard padded invocations so only real points are processed, preventing undefined GPU behavior on Metal

## Context
Issue #243 reports renderer corruption/GPU hangs on Apple Silicon when using Metal with the **Relax Position** modifier compute shader enabled. The issue comment narrowed it to this modifier.

Yup this is AI generated, but I did test and review the code by hand. This works as expected to resolve an issue with running on MacOS