### PR TITLE
Added default return val to scatter getter function - necessary for 4.7+

### DIFF
--- a/addons/proton_scatter/src/scatter.gd
+++ b/addons/proton_scatter/src/scatter.gd
@@ -290,7 +290,7 @@ func _get(property):
 
 	elif property == "Performance/chunk_dimensions":
 		return chunk_dimensions
-
+	return null
 
 func is_thread_running() -> bool:
 	return _thread != null and _thread.is_started()


### PR DESCRIPTION
Added default return val to scatter getter function - necessary for 4.7+