### PR TITLE
Fix cache restore fallback when entries are missing

### DIFF
--- a/addons/proton_scatter/src/cache/scatter_cache.gd
+++ b/addons/proton_scatter/src/cache/scatter_cache.gd
@@ -82,7 +82,6 @@ func _ready() -> void:
 
 		# Set the cache path to the cache folder, incorporating the scene name
 		cache_file = DEFAULT_CACHE_FOLDER.get_basename().path_join(scene_name + "_scatter_cache.res")
-		return
 
 	restore_cache.call_deferred()
 
@@ -153,7 +152,7 @@ func update_cache() -> void:
 			continue # Move on to the next if still no results.
 
 		# Store the transforms in the cache.
-		_local_cache.store(_scene_root.get_path_to(s), s.transforms.list)
+		_local_cache.store(str(_scene_root.get_path_to(s)), s.transforms.list)
 		_scatter_nodes[s] = s.build_version
 		_local_cache_changed = true
 
@@ -173,36 +172,50 @@ func update_cache() -> void:
 
 
 func restore_cache() -> void:
-	# Load the cache file if it exists
-	if not ResourceLoader.exists(cache_file):
-		printerr("Could not find cache file ", cache_file)
-		return
-
-	if is_inside_tree():
-		if dbg_disable_thread:
-			_load_cache(cache_file)
-		else:
-			await _load_cache_threaded(cache_file)
-	else:
-		_local_cache = load(cache_file)
-	if not _local_cache:
-		printerr("Could not load cache: ", cache_file)
-		return
-
 	_scatter_nodes.clear()
 	_discover_scatter_nodes(_scene_root)
+
+	var cache_loaded := false
+
+	# Load the cache file if it exists
+	if ResourceLoader.exists(cache_file):
+		if is_inside_tree():
+			if dbg_disable_thread:
+				_load_cache(cache_file)
+			else:
+				await _load_cache_threaded(cache_file)
+		else:
+			_local_cache = load(cache_file)
+
+		if not _local_cache:
+			printerr("Could not load cache: ", cache_file)
+		else:
+			cache_loaded = true
+	else:
+		push_warning("ProtonScatter warning: Could not find cache file %s. Falling back to rebuilding scatter nodes." % cache_file)
 
 	for s in _scatter_nodes:
 		if s.force_rebuild_on_load:
 			continue # Ignore the cache if the scatter node is about to rebuild anyway.
 
-		# Send the cached transforms to the scatter node.
-		var transforms = ProtonScatterTransformList.new()
-		transforms.list = _local_cache.get_transforms(_scene_root.get_path_to(s))
-		s._perform_sanity_check()
-		s._on_transforms_ready(transforms)
-		s.build_version = 0
-		_scatter_nodes[s] = 0
+		var node_path := str(_scene_root.get_path_to(s))
+
+		if cache_loaded and _local_cache.has_transforms(node_path):
+			# Send the cached transforms to the scatter node.
+			var transforms = ProtonScatterTransformList.new()
+			transforms.list = _local_cache.get_transforms(node_path)
+			s._perform_sanity_check()
+			s._on_transforms_ready(transforms)
+			s.build_version = 0
+			_scatter_nodes[s] = 0
+			continue
+
+		if cache_loaded:
+			push_warning("ProtonScatter warning: Cache miss for node %s. Rebuilding node output." % node_path)
+
+		s.rebuild.call_deferred()
+		await s.build_completed
+		_scatter_nodes[s] = s.build_version
 
 	cache_restored.emit()
 
@@ -253,7 +266,7 @@ func _ensure_cache_folder_exists() -> void:
 
 
 func _load_cache(cache_file_path: String) -> void:
-	_local_cache = ResourceLoader.load(cache_file)
+	_local_cache = ResourceLoader.load(cache_file_path)
 
 
 func _load_cache_threaded(cache_file: String) -> void:

--- a/addons/proton_scatter/src/common/cache_resource.gd
+++ b/addons/proton_scatter/src/common/cache_resource.gd
@@ -10,6 +10,10 @@ func clear() -> void:
 	data.clear()
 
 
+func has_transforms(node_path: String) -> bool:
+	return data.has(node_path) or data.has(NodePath(node_path))
+
+
 func store(node_path: String, transforms: Array[Transform3D]) -> void:
 	data[node_path] = transforms
 
@@ -23,5 +27,10 @@ func get_transforms(node_path: String) -> Array[Transform3D]:
 
 	if node_path in data:
 		res.assign(data[node_path])
+		return res
+
+	var as_node_path := NodePath(node_path)
+	if as_node_path in data:
+		res.assign(data[as_node_path])
 
 	return res


### PR DESCRIPTION
## Summary
- Fixes a cache restore edge case where `ProtonScatterCache` could leave scatter output empty when cache data is missing.
- Adds a safe fallback so nodes rebuild when cache file/entries are unavailable.
- Improves cache key compatibility to handle both `String` and `NodePath` path keys.

## Problem
When using `ProtonScatterCache` with `force_rebuild_on_load = false`, some scenes could load with no scattered instances unless users forced rebuild every run.

This happened when:
- the cache file did not exist yet, or
- the cache file existed but did not contain an entry for a specific `ProtonScatter` node.

## Root Cause
- `restore_cache()` assumed cache data existed for all discovered scatter nodes.
- Missing cache entries were not handled as a rebuild fallback.
- Cache keys could mismatch by type (`String` vs `NodePath`), causing misses.
- `_ready()` returned early after auto-generating a default cache path, skipping restore flow on first setup.

## What This PR Changes

### `addons/proton_scatter/src/cache/scatter_cache.gd`
- Removes the early `return` after default `cache_file` generation in `_ready()`.
- Reworks `restore_cache()` to:
  - discover scatter nodes first,
  - load cache only if present,
  - restore transforms only when node cache entry exists,
  - rebuild node output when cache file is missing or entry is missing.
- Adds warnings for missing cache file and per-node cache miss.
- Stores cache keys as `String` paths consistently.
- Fixes `_load_cache(cache_file_path)` to use its parameter.

### `addons/proton_scatter/src/common/cache_resource.gd`
- Adds `has_transforms(node_path)` helper.
- Adds compatibility lookup for both `String` and `NodePath` keys in:
  - `has_transforms()`
  - `get_transforms()`

## Result
- Cache restore still works for valid cache entries.
- Missing cache file/entry now triggers rebuild instead of empty output.
- Users no longer need to keep `force_rebuild_on_load` enabled just to avoid missing scatter output.

## Notes
- This keeps existing successful cache behavior intact and only changes failure/miss handling.
- Path key compatibility helps with previously saved cache resources.
