### PR TITLE
Fix/cache

### DIFF
--- a/addons/proton_scatter/src/cache/scatter_cache.gd
+++ b/addons/proton_scatter/src/cache/scatter_cache.gd
@@ -48,6 +48,7 @@ var _scene_root: Node
 var _scatter_nodes: Dictionary # Key: ProtonScatter, Value: cached version
 var _local_cache_changed := false
 var _cache_load_threaded_in_progress := false
+var _save_pending := false
 
 var _save_thread = Thread.new()
 
@@ -59,6 +60,11 @@ func _ready() -> void:
 
 	_scene_root = _get_local_scene_root(self)
 	_migrate_legacy_cache_file()
+
+	# The presence of this node signals "use cached transforms at load time".
+	# Flip force_rebuild_on_load off on every scatter under our scope so
+	# restore_cache actually applies the cache instead of being skipped.
+	enable_for_all_nodes()
 
 	restore_cache.call_deferred()
 
@@ -89,7 +95,9 @@ func _get_configuration_warnings() -> PackedStringArray:
 
 func _notification(what):
 	if what == NOTIFICATION_EDITOR_PRE_SAVE and auto_rebuild_cache_when_saving:
-		update_cache()
+		# Must be synchronous: _notification does not wait for coroutines,
+		# so the scene would otherwise be written before the cache is flushed.
+		_update_cache_sync()
 
 
 func clear_cache() -> void:
@@ -137,6 +145,40 @@ func update_cache() -> void:
 	_local_cache_changed = false
 
 
+# Synchronous variant used from NOTIFICATION_EDITOR_PRE_SAVE. Must not await,
+# because Godot proceeds with the scene save as soon as _notification returns.
+# Only stores transforms that are already available; cold nodes are skipped
+# with a warning so the next save (after the node has built) picks them up.
+func _update_cache_sync() -> void:
+	_ensure_cache_resource_exists()
+
+	_purge_outdated_nodes()
+	_discover_scatter_nodes(_scene_root)
+
+	if not _local_cache:
+		_local_cache = cache_resource
+
+	for s in _scatter_nodes:
+		var cached_version: int = _scatter_nodes[s]
+		if s.build_version == cached_version:
+			continue
+
+		if not s.transforms:
+			push_warning("ProtonScatter: node %s has no transforms yet; skipping in save-time cache. Use 'Update Cache' to force a build." % str(_scene_root.get_path_to(s)))
+			continue
+
+		_local_cache.store(str(_scene_root.get_path_to(s)), s.transforms.list)
+		_scatter_nodes[s] = s.build_version
+		_local_cache_changed = true
+
+	if not _local_cache_changed:
+		return
+
+	# Flush synchronously so the .res is on disk before the scene is written.
+	save_cache()
+	_local_cache_changed = false
+
+
 func restore_cache() -> void:
 	_scatter_nodes.clear()
 	_discover_scatter_nodes(_scene_root)
@@ -166,18 +208,16 @@ func restore_cache() -> void:
 		push_warning("ProtonScatter warning: Could not find cache file %s. Falling back to rebuilding scatter nodes." % cache_path)
 
 	for s in _scatter_nodes:
-		if s.force_rebuild_on_load:
-			continue # Ignore the cache if the scatter node is about to rebuild anyway.
-
 		var node_path := str(_scene_root.get_path_to(s))
 
 		if cache_loaded and _local_cache.has_transforms(node_path):
-			# Send the cached transforms to the scatter node.
+			# Apply the cached transforms synchronously, bypassing the build
+			# thread. apply_cached_transforms leaves build_version at 0 so
+			# the next update_cache sees no work to do until the user edits.
 			var transforms = ProtonScatterTransformList.new()
 			transforms.list = _local_cache.get_transforms(node_path)
 			s._perform_sanity_check()
-			s._on_transforms_ready(transforms)
-			s.build_version = 0
+			s.apply_cached_transforms(transforms)
 			_scatter_nodes[s] = 0
 			continue
 
@@ -239,7 +279,7 @@ func _request_save_cache() -> void:
 	_ensure_cache_resource_exists()
 	var save_path := _get_cache_path()
 	if save_path.is_empty():
-		printerr("ProtonScatter error: Cache resource has no save path.")
+		push_warning("ProtonScatter: cache not saved — scene has no file path yet. Save the scene first.")
 		return
 
 	var cache_dir := save_path.get_base_dir()
@@ -250,27 +290,37 @@ func _request_save_cache() -> void:
 		save_cache()
 		return
 
-	if !_save_thread.is_alive():
-		if _save_thread.is_started():
-			_save_thread.wait_to_finish()
-		_save_thread.start(save_cache)
+	if _save_thread.is_alive():
+		# A save is already running. Flag that another pass is needed; the
+		# running thread body will pick it up instead of dropping the request.
+		_save_pending = true
+		return
+
+	if _save_thread.is_started():
+		_save_thread.wait_to_finish()
+	_save_thread.start(_save_cache_thread_body)
+
+
+func _save_cache_thread_body() -> void:
+	save_cache()
+	while _save_pending:
+		_save_pending = false
+		save_cache()
 
 
 func _get_default_cache_path() -> String:
 	if not is_instance_valid(_scene_root):
 		return ""
 
+	var scene_path: String = _scene_root.get_scene_file_path()
+	if scene_path.is_empty():
+		# Scene has not been saved yet. Returning empty prevents creating
+		# orphan cache files under a randomized name on every save attempt.
+		return ""
+
 	_ensure_cache_folder_exists()
 
-	var scene_path: String = _scene_root.get_scene_file_path()
-	var scene_name: String
-
-	if scene_path.is_empty():
-		scene_name = str(randi())
-	else:
-		scene_name = scene_path.get_file().get_basename()
-		scene_name += "_" + str(scene_path.hash())
-
+	var scene_name := scene_path.get_file().get_basename() + "_" + str(scene_path.hash())
 	return DEFAULT_CACHE_FOLDER.get_basename().path_join(scene_name + "_scatter_cache.res")
 
 
@@ -334,6 +384,14 @@ func _load_cache_threaded(cache_file: String) -> void:
 		printerr("Cache file path is empty.")
 		return
 
+	# A previous load may still be in flight (e.g. rapid scene reloads).
+	# Wait for it to finish and piggyback on its result instead of racing
+	# the shared signal.
+	if _cache_load_threaded_in_progress:
+		await cache_load_threaded_finished
+		_local_cache = ResourceLoader.load_threaded_get(cache_file)
+		return
+
 	ResourceLoader.load_threaded_request(cache_file)
 	set_process(true)
 	_cache_load_threaded_in_progress = true
@@ -361,10 +419,20 @@ func save_cache() -> void:
 		return
 
 	cache_file = save_path
+	# save_cache may run on a worker thread; bounce property assignment back
+	# to the main thread so the cache_resource setter and its
+	# update_configuration_warnings() call don't touch the scene tree
+	# off-thread.
 	if cache_resource.resource_path.is_empty() and ResourceLoader.exists(save_path):
-		var saved_resource = load(save_path)
-		if saved_resource is ProtonScatterCacheResource:
-			cache_resource = saved_resource
+		_refresh_cache_resource_from_disk.call_deferred(save_path)
+
+
+func _refresh_cache_resource_from_disk(save_path: String) -> void:
+	if not ResourceLoader.exists(save_path):
+		return
+	var saved_resource = load(save_path)
+	if saved_resource is ProtonScatterCacheResource:
+		cache_resource = saved_resource
 
 
 func _exit_tree():

--- a/addons/proton_scatter/src/cache/scatter_cache.gd
+++ b/addons/proton_scatter/src/cache/scatter_cache.gd
@@ -22,11 +22,13 @@ signal cache_restored
 signal cache_load_threaded_finished
 
 
-@export_file("*.res", "*.tres") var cache_file := "":
+@export var cache_resource: ProtonScatterCacheResource:
 	set(val):
-		cache_file = val
+		cache_resource = val
 		if is_inside_tree():
 			update_configuration_warnings()
+
+@export_storage var cache_file := ""
 
 
 ## Determines whether the cache should be automatically updated when the scene is saved.
@@ -56,39 +58,14 @@ func _ready() -> void:
 		return
 
 	_scene_root = _get_local_scene_root(self)
-
-	# Check if cache_file is empty, indicating the default case
-	if cache_file.is_empty():
-		if Engine.is_editor_hint():
-			# Ensure the cache folder exists
-			_ensure_cache_folder_exists()
-		else:
-			printerr("ProtonScatter error: You loaded a ScatterCache node with an empty cache file attribute.
-								ProtonScatter cannot set a default value outside of the editor.
-								Please open the scene in the editor and set a default value.")
-			return
-
-		# Retrieve the scene name to create a unique recognizable name
-		var scene_path: String = _scene_root.get_scene_file_path()
-		var scene_name: String
-
-		# If the scene path is not available, set a random name
-		if scene_path.is_empty():
-			scene_name = str(randi())
-		else:
-			# Use the base name of the scene file and append a hash to avoid collisions
-			scene_name = scene_path.get_file().get_basename()
-			scene_name += "_" + str(scene_path.hash())
-
-		# Set the cache path to the cache folder, incorporating the scene name
-		cache_file = DEFAULT_CACHE_FOLDER.get_basename().path_join(scene_name + "_scatter_cache.res")
+	_migrate_legacy_cache_file()
 
 	restore_cache.call_deferred()
 
 
 func _process(_delta: float) -> void:
 	if _cache_load_threaded_in_progress:
-		match ResourceLoader.load_threaded_get_status(cache_file):
+		match ResourceLoader.load_threaded_get_status(_get_cache_path()):
 			ResourceLoader.ThreadLoadStatus.THREAD_LOAD_IN_PROGRESS:
 				return
 
@@ -102,8 +79,10 @@ func _process(_delta: float) -> void:
 
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings = PackedStringArray()
-	if cache_file.is_empty():
-		warnings.push_back("No path set for the cache file. Select where to store the cache in the inspector.")
+	if not cache_resource:
+		warnings.push_back("No cache resource assigned. Create or load a ProtonScatterCacheResource in the inspector.")
+	elif cache_resource.resource_path.is_empty():
+		warnings.push_back("The cache resource is embedded in the scene. Save it as an external resource to persist cache data across sessions.")
 
 	return warnings
 
@@ -115,27 +94,20 @@ func _notification(what):
 
 func clear_cache() -> void:
 	_scatter_nodes.clear()
+	_ensure_cache_resource_exists()
+	_local_cache = cache_resource
 	_local_cache.clear()
-
-	if dbg_disable_thread:
-		save_cache()
-	else:
-		if !_save_thread.is_alive():
-			if _save_thread.is_started():
-				_save_thread.wait_to_finish()
-			_save_thread.start(save_cache)
+	_request_save_cache()
 
 
 func update_cache() -> void:
-	if cache_file.is_empty():
-		printerr("Cache file path is empty.")
-		return
+	_ensure_cache_resource_exists()
 
 	_purge_outdated_nodes()
 	_discover_scatter_nodes(_scene_root)
 
 	if not _local_cache:
-		_local_cache = ProtonScatterCacheResource.new()
+		_local_cache = cache_resource
 
 	for s in _scatter_nodes:
 		# Ignore this node if its cache is already up to date
@@ -160,13 +132,7 @@ func update_cache() -> void:
 	if not _local_cache_changed:
 		return
 
-	if dbg_disable_thread:
-		save_cache()
-	else:
-		if !_save_thread.is_alive():
-			if _save_thread.is_started():
-				_save_thread.wait_to_finish()
-			_save_thread.start(save_cache)
+	_request_save_cache()
 
 	_local_cache_changed = false
 
@@ -176,23 +142,28 @@ func restore_cache() -> void:
 	_discover_scatter_nodes(_scene_root)
 
 	var cache_loaded := false
+	var cache_path := _get_cache_path()
+	if cache_resource:
+		_local_cache = cache_resource
+		cache_loaded = true
 
 	# Load the cache file if it exists
-	if ResourceLoader.exists(cache_file):
+	if not cache_loaded and ResourceLoader.exists(cache_path):
 		if is_inside_tree():
 			if dbg_disable_thread:
-				_load_cache(cache_file)
+				_load_cache(cache_path)
 			else:
-				await _load_cache_threaded(cache_file)
+				await _load_cache_threaded(cache_path)
 		else:
-			_local_cache = load(cache_file)
+			_local_cache = load(cache_path)
 
 		if not _local_cache:
-			printerr("Could not load cache: ", cache_file)
+			printerr("Could not load cache: ", cache_path)
 		else:
+			cache_resource = _local_cache
 			cache_loaded = true
-	else:
-		push_warning("ProtonScatter warning: Could not find cache file %s. Falling back to rebuilding scatter nodes." % cache_file)
+	elif not cache_loaded and not cache_path.is_empty():
+		push_warning("ProtonScatter warning: Could not find cache file %s. Falling back to rebuilding scatter nodes." % cache_path)
 
 	for s in _scatter_nodes:
 		if s.force_rebuild_on_load:
@@ -240,6 +211,79 @@ func _get_local_scene_root(node: Node) -> Node:
 	return _get_local_scene_root(parent)
 
 
+func _migrate_legacy_cache_file() -> void:
+	if cache_resource:
+		return
+
+	if cache_file.is_empty():
+		return
+
+	if ResourceLoader.exists(cache_file):
+		var loaded_resource = load(cache_file)
+		if loaded_resource is ProtonScatterCacheResource:
+			cache_resource = loaded_resource
+			return
+
+	cache_resource = ProtonScatterCacheResource.new()
+
+
+func _ensure_cache_resource_exists() -> void:
+	if cache_resource:
+		return
+
+	cache_resource = ProtonScatterCacheResource.new()
+	update_configuration_warnings()
+
+
+func _request_save_cache() -> void:
+	_ensure_cache_resource_exists()
+	var save_path := _get_cache_path()
+	if save_path.is_empty():
+		printerr("ProtonScatter error: Cache resource has no save path.")
+		return
+
+	var cache_dir := save_path.get_base_dir()
+	if not _ensure_cache_directory_exists(cache_dir):
+		return
+
+	if dbg_disable_thread or not ResourceLoader.exists(save_path):
+		save_cache()
+		return
+
+	if !_save_thread.is_alive():
+		if _save_thread.is_started():
+			_save_thread.wait_to_finish()
+		_save_thread.start(save_cache)
+
+
+func _get_default_cache_path() -> String:
+	if not is_instance_valid(_scene_root):
+		return ""
+
+	_ensure_cache_folder_exists()
+
+	var scene_path: String = _scene_root.get_scene_file_path()
+	var scene_name: String
+
+	if scene_path.is_empty():
+		scene_name = str(randi())
+	else:
+		scene_name = scene_path.get_file().get_basename()
+		scene_name += "_" + str(scene_path.hash())
+
+	return DEFAULT_CACHE_FOLDER.get_basename().path_join(scene_name + "_scatter_cache.res")
+
+
+func _get_cache_path() -> String:
+	if cache_resource and not cache_resource.resource_path.is_empty():
+		return cache_resource.resource_path
+
+	if not cache_file.is_empty():
+		return cache_file
+
+	return _get_default_cache_path()
+
+
 func _discover_scatter_nodes(node: Node) -> void:
 	if node is ProtonScatter and not _scatter_nodes.has(node):
 		_scatter_nodes[node] = -1
@@ -253,7 +297,8 @@ func _purge_outdated_nodes() -> void:
 	for node in _scatter_nodes:
 		if not is_instance_valid(node):
 			nodes_to_remove.push_back(node)
-			_local_cache.erase(_scene_root.get_path_to(node))
+			if _local_cache:
+				_local_cache.erase(str(_scene_root.get_path_to(node)))
 			_local_cache_changed = true
 
 	for node in nodes_to_remove:
@@ -261,8 +306,23 @@ func _purge_outdated_nodes() -> void:
 
 
 func _ensure_cache_folder_exists() -> void:
-	if not DirAccess.dir_exists_absolute(DEFAULT_CACHE_FOLDER):
-		DirAccess.make_dir_recursive_absolute(DEFAULT_CACHE_FOLDER)
+	_ensure_cache_directory_exists(DEFAULT_CACHE_FOLDER)
+
+
+func _ensure_cache_directory_exists(dir_path: String) -> bool:
+	if dir_path.is_empty():
+		return false
+
+	var absolute_dir := ProjectSettings.globalize_path(dir_path)
+	if DirAccess.dir_exists_absolute(absolute_dir):
+		return true
+
+	var err := DirAccess.make_dir_recursive_absolute(absolute_dir)
+	if err != OK:
+		printerr("ProtonScatter error: Failed to create cache directory ", dir_path, ". Code: ", err)
+		return false
+
+	return true
 
 
 func _load_cache(cache_file_path: String) -> void:
@@ -282,10 +342,29 @@ func _load_cache_threaded(cache_file: String) -> void:
 
 
 func save_cache() -> void:
-	var err = ResourceSaver.save(_local_cache, cache_file)
+	_ensure_cache_resource_exists()
+	_local_cache = cache_resource
+
+	var save_path := _get_cache_path()
+	if save_path.is_empty():
+		printerr("ProtonScatter error: Cache resource has no save path.")
+		return
+
+	var cache_dir := save_path.get_base_dir()
+	if not _ensure_cache_directory_exists(cache_dir):
+		return
+
+	var err = ResourceSaver.save(_local_cache, save_path)
 
 	if err != OK:
-		printerr("ProtonScatter error: Failed to save the cache file. Code: ", err)
+		printerr("ProtonScatter error: Failed to save the cache file ", save_path, ". Code: ", err)
+		return
+
+	cache_file = save_path
+	if cache_resource.resource_path.is_empty() and ResourceLoader.exists(save_path):
+		var saved_resource = load(save_path)
+		if saved_resource is ProtonScatterCacheResource:
+			cache_resource = saved_resource
 
 
 func _exit_tree():

--- a/addons/proton_scatter/src/cache/scatter_cache.gd
+++ b/addons/proton_scatter/src/cache/scatter_cache.gd
@@ -82,7 +82,6 @@ func _ready() -> void:
 
 		# Set the cache path to the cache folder, incorporating the scene name
 		cache_file = DEFAULT_CACHE_FOLDER.get_basename().path_join(scene_name + "_scatter_cache.res")
-		return
 
 	restore_cache.call_deferred()
 
@@ -153,7 +152,7 @@ func update_cache() -> void:
 			continue # Move on to the next if still no results.
 
 		# Store the transforms in the cache.
-		_local_cache.store(_scene_root.get_path_to(s), s.transforms.list)
+		_local_cache.store(str(_scene_root.get_path_to(s)), s.transforms.list)
 		_scatter_nodes[s] = s.build_version
 		_local_cache_changed = true
 
@@ -173,36 +172,50 @@ func update_cache() -> void:
 
 
 func restore_cache() -> void:
-	# Load the cache file if it exists
-	if not ResourceLoader.exists(cache_file):
-		printerr("Could not find cache file ", cache_file)
-		return
-
-	if is_inside_tree():
-		if dbg_disable_thread:
-			_load_cache(cache_file)
-		else:
-			await _load_cache_threaded(cache_file)
-	else:
-		_local_cache = load(cache_file)
-	if not _local_cache:
-		printerr("Could not load cache: ", cache_file)
-		return
-
 	_scatter_nodes.clear()
 	_discover_scatter_nodes(_scene_root)
+
+	var cache_loaded := false
+
+	# Load the cache file if it exists
+	if ResourceLoader.exists(cache_file):
+		if is_inside_tree():
+			if dbg_disable_thread:
+				_load_cache(cache_file)
+			else:
+				await _load_cache_threaded(cache_file)
+		else:
+			_local_cache = load(cache_file)
+
+		if not _local_cache:
+			printerr("Could not load cache: ", cache_file)
+		else:
+			cache_loaded = true
+	else:
+		push_warning("ProtonScatter warning: Could not find cache file %s. Falling back to rebuilding scatter nodes." % cache_file)
 
 	for s in _scatter_nodes:
 		if s.force_rebuild_on_load:
 			continue # Ignore the cache if the scatter node is about to rebuild anyway.
 
-		# Send the cached transforms to the scatter node.
-		var transforms = ProtonScatterTransformList.new()
-		transforms.list = _local_cache.get_transforms(_scene_root.get_path_to(s))
-		s._perform_sanity_check()
-		s._on_transforms_ready(transforms)
-		s.build_version = 0
-		_scatter_nodes[s] = 0
+		var node_path := str(_scene_root.get_path_to(s))
+
+		if cache_loaded and _local_cache.has_transforms(node_path):
+			# Send the cached transforms to the scatter node.
+			var transforms = ProtonScatterTransformList.new()
+			transforms.list = _local_cache.get_transforms(node_path)
+			s._perform_sanity_check()
+			s._on_transforms_ready(transforms)
+			s.build_version = 0
+			_scatter_nodes[s] = 0
+			continue
+
+		if cache_loaded:
+			push_warning("ProtonScatter warning: Cache miss for node %s. Rebuilding node output." % node_path)
+
+		s.rebuild.call_deferred()
+		await s.build_completed
+		_scatter_nodes[s] = s.build_version
 
 	cache_restored.emit()
 
@@ -253,7 +266,7 @@ func _ensure_cache_folder_exists() -> void:
 
 
 func _load_cache(cache_file_path: String) -> void:
-	_local_cache = ResourceLoader.load(cache_file)
+	_local_cache = ResourceLoader.load(cache_file_path)
 
 
 func _load_cache_threaded(cache_file: String) -> void:

--- a/addons/proton_scatter/src/common/cache_resource.gd
+++ b/addons/proton_scatter/src/common/cache_resource.gd
@@ -10,6 +10,10 @@ func clear() -> void:
 	data.clear()
 
 
+func has_transforms(node_path: String) -> bool:
+	return data.has(node_path) or data.has(NodePath(node_path))
+
+
 func store(node_path: String, transforms: Array[Transform3D]) -> void:
 	data[node_path] = transforms
 
@@ -23,5 +27,10 @@ func get_transforms(node_path: String) -> Array[Transform3D]:
 
 	if node_path in data:
 		res.assign(data[node_path])
+		return res
+
+	var as_node_path := NodePath(node_path)
+	if as_node_path in data:
+		res.assign(data[as_node_path])
 
 	return res

--- a/addons/proton_scatter/src/scatter.gd
+++ b/addons/proton_scatter/src/scatter.gd
@@ -189,8 +189,17 @@ func _ready() -> void:
 	update_configuration_warnings.call_deferred()
 	is_ready = true
 
-	if force_rebuild_on_load and not is_instance_valid(_dependency_parent):
-		full_rebuild.call_deferred()
+	if not is_instance_valid(_dependency_parent):
+		# Deferred so a ProtonScatterCache further up the tree has a chance to
+		# flip force_rebuild_on_load off in its own _ready before the rebuild
+		# actually runs. Otherwise the rebuild would fire and overwrite the
+		# cache-applied transforms a moment later.
+		_maybe_initial_rebuild.call_deferred()
+
+
+func _maybe_initial_rebuild() -> void:
+	if force_rebuild_on_load:
+		full_rebuild()
 
 
 func _exit_tree():
@@ -738,6 +747,38 @@ func _on_node_duplicated() -> void:
 func _on_child_exiting_tree(node: Node) -> void:
 	if node is ProtonScatterShape or node is ProtonScatterItem:
 		rebuild.bind(true).call_deferred()
+
+
+# Synchronous variant used by ProtonScatterCache to apply cached transforms
+# without spinning up the build thread or waiting on a process frame. Leaves
+# build_version at 0 so the cache treats the node as "in cached state".
+func apply_cached_transforms(list: ProtonScatterTransformList) -> void:
+	_clear_collision_data()
+
+	transforms = list
+
+	if force_uniform_scale or _is_using_jolt:
+		transforms.enforce_uniform_scale()
+
+	if not transforms or transforms.is_empty():
+		clear_output()
+		update_gizmos()
+		build_version = 0
+		return
+
+	match render_mode:
+		0:
+			if use_chunks:
+				_update_split_multimeshes()
+			else:
+				_update_multimeshes()
+		1:
+			_update_duplicates()
+		2:
+			_update_particles_system()
+
+	update_gizmos()
+	build_version = 0
 
 
 # Called when the modifier stack is done generating the full transform list


### PR DESCRIPTION
## Summary
- Fixes `ScatterCache` so missing cache data no longer leaves scatter output empty.
- Falls back to rebuilding when the cache file or a node entry is missing.
- Replaces the path-based cache field with a standard Godot resource picker workflow.

## Details
- `restore_cache()` now restores only when matching cached transforms exist.
- Cache misses now rebuild node output instead of silently clearing it.
- Cache key lookup now supports both `String` and `NodePath` formats.
- `ScatterCache` now uses an exported `ProtonScatterCacheResource` for the inspector UI.
- Legacy `cache_file` setups are kept compatible and migrated when possible.
- First-time cache creation/save is handled more safely.

## Result
- Cache restore is more reliable.
- First-time cache setup is more intuitive.
- Existing projects keep working while gaining the new workflow.