### PR TITLE
Fix root node type of preset scenes

### DIFF
--- a/addons/proton_scatter/src/stack/inspector_plugin/ui/presets/load_preset.tscn
+++ b/addons/proton_scatter/src/stack/inspector_plugin/ui/presets/load_preset.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/presets/load_preset.gd" id="1"]
 
-[node name="LoadPresetPopup" type="WindowDialog"]
+[node name="LoadPresetPopup" type="Window"]
 visible = true
 anchor_left = 0.5
 anchor_top = 0.5

--- a/addons/proton_scatter/src/stack/inspector_plugin/ui/presets/save_preset.tscn
+++ b/addons/proton_scatter/src/stack/inspector_plugin/ui/presets/save_preset.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://addons/proton_scatter/src/stack/inspector_plugin/ui/presets/save_preset.gd" id="1"]
 
-[node name="SavePresetPopup" type="WindowDialog"]
+[node name="SavePresetPopup" type="Window"]
 visible = true
 anchor_left = 0.5
 anchor_top = 0.5
@@ -48,7 +48,7 @@ modulate = Color( 1, 0.513726, 0.278431, 1 )
 margin_right = 312.0
 margin_bottom = 48.0
 text = "Preset name must be a valid file name.
-It cannot contain the following characters: 
+It cannot contain the following characters:
 : / \\\\ ? * \" | % < >"
 valign = 2
 autowrap = true


### PR DESCRIPTION
The type of the root nodes of the `save_preset.tscn` and `load_preset.tscn` were wrongly configured as `WindowDialog`, which does not exist in Godot 4. Also the attached scripts themself inherit from `Window`.

<img width="385" height="248" alt="image" src="https://github.com/user-attachments/assets/852505c3-4b32-49eb-a6ce-52927406149c" />

After this fix the scenes work as intended.