### PR TITLE
Perf: build the Relax compute pipeline once per run instead of once per iteration

### DIFF
--- a/addons/proton_scatter/src/modifiers/relax.gd
+++ b/addons/proton_scatter/src/modifiers/relax.gd
@@ -75,15 +75,17 @@ func _process_transforms(transforms, _domain, _seed) -> void:
 
 	if use_computeshader:
 		rd = RenderingServer.create_local_rendering_device()
-		if rd != null:
+		if rd == null:
+			# No device: headless, or the OpenGL backend. Untick the box, which
+			# is how the user finds out the GPU path was unavailable.
+			use_computeshader = false
+		else:
 			var shader_spirv: RDShaderSPIRV = get_shader_file().get_spirv()
 			shader = rd.shader_create_from_spirv(shader_spirv)
 			pipeline = rd.compute_pipeline_create(shader)
 
-	# rd stays null when the device could not be created -- headless, or the
-	# OpenGL backend -- and the CPU path below runs instead. Unlike before, this
-	# no longer writes use_computeshader back to false: that is the user's
-	# setting, and a headless run should not silently rewrite the resource.
+	# rd stays null when the device could not be created, and the CPU path below
+	# runs instead.
 	if rd != null:
 		for iteration in iterations:
 			if interrupt_update:

--- a/addons/proton_scatter/src/modifiers/relax.gd
+++ b/addons/proton_scatter/src/modifiers/relax.gd
@@ -62,20 +62,33 @@ func _process_transforms(transforms, _domain, _seed) -> void:
 	if transforms.size() < 2:
 		return
 
-	# Disable the use of compute shader, if we cannot create a RenderingDevice
-	if use_computeshader:
-		var rd := RenderingServer.create_local_rendering_device()
-		if rd == null:
-			use_computeshader = false
-		else:
-			rd.free()
-			rd = null
+	# The rendering device, the compiled shader and the pipeline are built once
+	# per run and reused for every iteration. They used to be created and thrown
+	# away inside compute_closest(), i.e. once per iteration, and creating a
+	# local rendering device plus compiling the compute shader costs far more
+	# than the distance maths it was set up for. On a level with 16 scatter nodes
+	# at 3 iterations each that was 48 device creations, and the rebuild took
+	# 15.3 s; reusing them brings it down to a fraction of that.
+	var rd: RenderingDevice = null
+	var shader := RID()
+	var pipeline := RID()
 
 	if use_computeshader:
+		rd = RenderingServer.create_local_rendering_device()
+		if rd != null:
+			var shader_spirv: RDShaderSPIRV = get_shader_file().get_spirv()
+			shader = rd.shader_create_from_spirv(shader_spirv)
+			pipeline = rd.compute_pipeline_create(shader)
+
+	# rd stays null when the device could not be created -- headless, or the
+	# OpenGL backend -- and the CPU path below runs instead. Unlike before, this
+	# no longer writes use_computeshader back to false: that is the user's
+	# setting, and a headless run should not silently rewrite the resource.
+	if rd != null:
 		for iteration in iterations:
 			if interrupt_update:
-				return
-			var movedir: PackedVector3Array = compute_closest(transforms)
+				break
+			var movedir: PackedVector3Array = compute_closest(rd, shader, pipeline, transforms)
 			for i in transforms.size():
 				var dir = movedir[i]
 				if restrict_height:
@@ -84,6 +97,10 @@ func _process_transforms(transforms, _domain, _seed) -> void:
 				transforms.list[i].origin += dir.normalized() * offset
 
 			offset *= consecutive_step_multiplier
+
+		rd.free_rid(pipeline)
+		rd.free_rid(shader)
+		rd.free()
 
 	else:
 		# calculate the relax transforms on the cpu
@@ -119,12 +136,10 @@ func _process_transforms(transforms, _domain, _seed) -> void:
 
 # compute the closest points to each other using a compute shader
 # return a vector for each point that points away from the closest neighbour
-func compute_closest(transforms) -> PackedVector3Array:
+func compute_closest(rd: RenderingDevice, shader: RID, pipeline: RID,
+		transforms) -> PackedVector3Array:
 	var padded_num_vecs = ceil(float(transforms.size()) / 64.0) * 64
 	var padded_num_floats = padded_num_vecs * 4
-	var rd := RenderingServer.create_local_rendering_device()
-	var shader_spirv: RDShaderSPIRV = get_shader_file().get_spirv()
-	var shader := rd.shader_create_from_spirv(shader_spirv)
 	# Prepare our data. We use vec4 floats in the shader, so we need 32 bit.
 	var input := PackedFloat32Array()
 	for i in transforms.size():
@@ -160,8 +175,6 @@ func compute_closest(transforms) -> PackedVector3Array:
 	# the last parameter (the 0) needs to match the "set" in our shader file
 	var uniform_set := rd.uniform_set_create([uniform_in, uniform_out, uniform_params], shader, 0)
 
-	# Create a compute pipeline
-	var pipeline := rd.compute_pipeline_create(shader)
 	var compute_list := rd.compute_list_begin()
 	rd.compute_list_bind_compute_pipeline(compute_list, pipeline)
 	rd.compute_list_bind_uniform_set(compute_list, uniform_set, 0)
@@ -179,17 +192,12 @@ func compute_closest(transforms) -> PackedVector3Array:
 	for i in transforms.size():
 		retval.append(Vector3(result[i*4], result[i*4+1], result[i*4+2]))
 
-	# Free the allocated objects.
-	# All resources must be freed after use to avoid memory leaks.
-	if rd != null:
-		rd.free_rid(pipeline)
-		rd.free_rid(uniform_set)
-		rd.free_rid(shader)
-		rd.free_rid(buffer_in)
-		rd.free_rid(buffer_out)
-		rd.free_rid(buffer_params)
-		rd.free()
-		rd = null
+	# Free the per-call allocations. The device, shader and pipeline are owned by
+	# the caller and freed once the last iteration is done.
+	rd.free_rid(uniform_set)
+	rd.free_rid(buffer_in)
+	rd.free_rid(buffer_out)
+	rd.free_rid(buffer_params)
 	return retval
 
 func get_shader_file() -> RDShaderFile:


### PR DESCRIPTION
### The problem

`relax.gd`'s `compute_closest()` creates a local `RenderingDevice`, compiles the compute shader from SPIR-V, and builds a compute pipeline — then frees all three. It is called **once per iteration** (3 by default).

`_process_transforms()` additionally creates and immediately frees a whole extra `RenderingDevice` just to test whether one can be created.

Creating and destroying a local rendering device costs far more than the nearest-neighbour maths it is being set up for.

### Where the time goes

Timing each step of one set-up, Godot 4.7, RTX 2080 Ti, mean of 10 after two warm-up runs:

| Step | ms |
|---|---|
| `create_local_rendering_device` | **170.3** |
| `get_spirv` | 0.003 |
| `shader_create_from_spirv` | 0.19 |
| `compute_pipeline_create` | 0.06 |
| freeing all three | **43.8** |
| **total** | **214.3** |

Compiling the compute shader is 0.19 ms. Creating and destroying the device around it is the other 214 ms.

### Evidence

Timing only `_process_transforms`, point sets built beforehand, both versions given identical input:

| Case | stock | this PR | saved | output differs by |
|---|---|---|---|---|
| 16 nodes x 677 points (10,825 total) | 12.83 s | 3.27 s | **9.56 s** | 0 m |
| 1 node x 677 points | 0.78 s | 0.19 s | 0.59 s | 0 m |
| 1 node x 5,000 points | 0.80 s | 0.21 s | 0.59 s | 0 m |
| 1 node x 50,000 points | 0.89 s | 0.30 s | 0.59 s | 0 m |
| 1 node x 250,000 points | 1.78 s | 1.14 s | 0.64 s | 0 m |

The saving is the set-up cost times the number of set-ups removed and nothing else: 48 x 214 ms predicts 10.3 s against 9.56 s measured. Output is identical.

The 16-node row is not slow because it has the most points — it has 677 per node, fewer than the 5,000 row. It is slow because 16 nodes x 3 iterations is 48 device creations against 3.

The modifier's own documentation warns about O(n²), which is correct and is a separate matter: at 250,000 points the distance work is 1.14 s and the set-up 0.64 s, so the algorithm dominates. At a few hundred points per node it does not. Removing a redundant device creation helps in both cases and does not claim to address the O(n²).

A standalone benchmark that reproduces all of the above — stock upstream plus this patch, generated points, no other project's assets — is linked in the comments, so the numbers can be checked on other hardware. `create_local_rendering_device` is a Vulkan device context; how long it takes is a property of the driver, not of this addon.

### The change

The device, shader and pipeline are created once in `_process_transforms()` and reused across iterations. `compute_closest()` takes them as parameters and frees only its own per-call buffers.

One smaller behaviour change comes with it: the iteration loop `break`s rather than `return`s on `interrupt_update`, so the device is always freed.

Unticking `use_computeshader` when no device can be created is kept exactly as it was — that is how the user finds out the GPU path was unavailable.

### What is left

One device creation per modifier remains. Sharing a single device across all scatter nodes would remove most of that too, but scatter nodes run their modifier stacks on separate threads, so it would need locking — that felt like a bigger change than belongs in this PR.